### PR TITLE
feat[SC-259] Profile model: contactmethoden voor digitale visitekaartjes

### DIFF
--- a/app/components/ProfileCard.vue
+++ b/app/components/ProfileCard.vue
@@ -1,9 +1,24 @@
 <script setup lang="ts">
 import type { Profile } from '~/types/profile'
 
-defineProps<{
+const props = defineProps<{
   profile: Profile
 }>()
+
+/** Get the primary contact (first in array) for the CTA */
+const primaryContact = computed(() => props.profile.contacts[0])
+
+/** Generate a display label for a contact type */
+function getContactLabel(type: string): string {
+  const labels: Record<string, string> = {
+    website: 'Bekijk website',
+    linkedin: 'LinkedIn',
+    github: 'GitHub',
+    email: 'E-mail',
+    phone: 'Bel'
+  }
+  return labels[type] ?? 'Contact'
+}
 </script>
 
 <template>
@@ -16,8 +31,9 @@ defineProps<{
         {{ profile.descriptor }}
       </p>
       <UButton
-        :to="profile.ctaLink"
-        :label="profile.ctaLabel"
+        v-if="primaryContact"
+        :to="primaryContact.url"
+        :label="primaryContact.label ?? getContactLabel(primaryContact.type)"
         target="_blank"
         size="lg"
       />

--- a/app/data/profiles.ts
+++ b/app/data/profiles.ts
@@ -5,14 +5,21 @@ export const profiles: Profile[] = [
     name: 'Marcel',
     slug: 'marcel',
     descriptor: 'Developer & Designer',
-    ctaLink: 'https://marcel.tuinstra.dev',
-    ctaLabel: 'Bekijk profiel'
+    contacts: [
+      { type: 'website', url: 'https://marcel.tuinstra.dev' },
+      { type: 'linkedin', url: 'https://linkedin.com/in/marceltuinstra' },
+      { type: 'github', url: 'https://github.com/marcel-tuinstra' },
+      { type: 'email', url: 'mailto:marcel@tuinstra.dev' }
+    ]
   },
   {
     name: 'Daan',
     slug: 'daan',
     descriptor: 'Developer & Gamer',
-    ctaLink: 'https://daan.tuinstra.dev',
-    ctaLabel: 'Bekijk profiel'
+    contacts: [
+      { type: 'linkedin', url: 'https://linkedin.com/in/daantuinstra' },
+      { type: 'github', url: 'https://github.com/daantuinstra' },
+      { type: 'email', url: 'mailto:daan@tuinstra.dev' }
+    ]
   }
 ]

--- a/app/types/profile.ts
+++ b/app/types/profile.ts
@@ -1,3 +1,16 @@
+/** Supported contact method types */
+export type ContactMethodType = 'website' | 'linkedin' | 'github' | 'email' | 'phone'
+
+/** A single contact method for a profile */
+export interface ContactMethod {
+  /** The type of contact method */
+  type: ContactMethodType
+  /** The URL or value (e.g., https://, mailto:, tel:) */
+  url: string
+  /** Optional custom label, otherwise derived from type */
+  label?: string
+}
+
 export interface Profile {
   /** Display name */
   name: string
@@ -5,8 +18,8 @@ export interface Profile {
   slug: string
   /** Short descriptor / role */
   descriptor: string
-  /** Call-to-action link (external portfolio or profile) */
-  ctaLink: string
-  /** Call-to-action label */
-  ctaLabel: string
+  /** Optional bio / tagline for the business card */
+  bio?: string
+  /** Contact methods displayed in order (all optional) */
+  contacts: ContactMethod[]
 }

--- a/tests/unit/profiles.test.ts
+++ b/tests/unit/profiles.test.ts
@@ -22,14 +22,28 @@ describe('profiles data', () => {
       expect(profile.name).toBeTruthy()
       expect(profile.slug).toBeTruthy()
       expect(profile.descriptor).toBeTruthy()
-      expect(profile.ctaLink).toBeTruthy()
-      expect(profile.ctaLabel).toBeTruthy()
+      expect(profile.contacts).toBeInstanceOf(Array)
+      expect(profile.contacts.length).toBeGreaterThan(0)
     }
   })
 
-  it('should have valid CTA links', () => {
+  it('should have valid contact URLs', () => {
+    const validTypes = ['website', 'linkedin', 'github', 'email', 'phone']
+
     for (const profile of profiles) {
-      expect(profile.ctaLink).toMatch(/^https?:\/\//)
+      for (const contact of profile.contacts) {
+        expect(validTypes).toContain(contact.type)
+        expect(contact.url).toBeTruthy()
+
+        // Validate URL format based on type
+        if (contact.type === 'email') {
+          expect(contact.url).toMatch(/^mailto:/)
+        } else if (contact.type === 'phone') {
+          expect(contact.url).toMatch(/^tel:/)
+        } else {
+          expect(contact.url).toMatch(/^https?:\/\//)
+        }
+      }
     }
   })
 })


### PR DESCRIPTION
## Summary
- Add `ContactMethodType` and `ContactMethod` interfaces to support multiple contact methods per profile
- Replace single `ctaLink`/`ctaLabel` with flexible `contacts` array (website, linkedin, github, email, phone)
- Update `ProfileCard` component to use first contact as primary CTA with auto-generated labels
- Update tests to validate new contact structure

## Context
This prepares the data model for the digital business card concept where each profile page shows multiple contact options with icons.

## Shortcut
https://app.shortcut.com/tuinstradev/story/259