### PR TITLE
feat[SC-181] Profielpagina template + routes (/marcel, /daan)

### DIFF
--- a/app/components/ContactButton.vue
+++ b/app/components/ContactButton.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import type { ContactMethod } from '~/types/profile'
+import { useContactMeta } from '~/composables/useContactMeta'
+
+const props = defineProps<{
+  contact: ContactMethod
+}>()
+
+const { getMeta } = useContactMeta()
+
+const meta = computed(() => getMeta(props.contact.type))
+const label = computed(() => props.contact.label ?? meta.value.label)
+const icon = computed(() => meta.value.icon)
+
+/** Determine if contact opens externally */
+const isExternal = computed(() => {
+  return props.contact.type !== 'email' && props.contact.type !== 'phone'
+})
+</script>
+
+<template>
+  <UButton
+    :to="contact.url"
+    :icon="icon"
+    :label="label"
+    :target="isExternal ? '_blank' : undefined"
+    variant="outline"
+    color="neutral"
+    size="xl"
+    block
+    class="justify-start"
+  />
+</template>

--- a/app/components/ProfileCard.vue
+++ b/app/components/ProfileCard.vue
@@ -1,28 +1,16 @@
 <script setup lang="ts">
 import type { Profile } from '~/types/profile'
 
-const props = defineProps<{
+defineProps<{
   profile: Profile
 }>()
-
-/** Get the primary contact (first in array) for the CTA */
-const primaryContact = computed(() => props.profile.contacts[0])
-
-/** Generate a display label for a contact type */
-function getContactLabel(type: string): string {
-  const labels: Record<string, string> = {
-    website: 'Bekijk website',
-    linkedin: 'LinkedIn',
-    github: 'GitHub',
-    email: 'E-mail',
-    phone: 'Bel'
-  }
-  return labels[type] ?? 'Contact'
-}
 </script>
 
 <template>
-  <UCard class="text-center">
+  <UCard
+    :to="`/${profile.slug}`"
+    class="text-center hover:ring-2 hover:ring-primary transition-all cursor-pointer"
+  >
     <div class="space-y-3">
       <h2 class="text-2xl font-bold">
         {{ profile.name }}
@@ -31,11 +19,10 @@ function getContactLabel(type: string): string {
         {{ profile.descriptor }}
       </p>
       <UButton
-        v-if="primaryContact"
-        :to="primaryContact.url"
-        :label="primaryContact.label ?? getContactLabel(primaryContact.type)"
-        target="_blank"
+        :to="`/${profile.slug}`"
+        label="Bekijk profiel"
         size="lg"
+        trailing-icon="i-lucide-arrow-right"
       />
     </div>
   </UCard>

--- a/app/composables/useContactMeta.ts
+++ b/app/composables/useContactMeta.ts
@@ -1,0 +1,37 @@
+import type { ContactMethodType } from '~/types/profile'
+
+export interface ContactMeta {
+  icon: string
+  label: string
+}
+
+const contactMeta: Record<ContactMethodType, ContactMeta> = {
+  website: { icon: 'i-lucide-globe', label: 'Website' },
+  linkedin: { icon: 'i-simple-icons-linkedin', label: 'LinkedIn' },
+  github: { icon: 'i-simple-icons-github', label: 'GitHub' },
+  email: { icon: 'i-lucide-mail', label: 'E-mail' },
+  phone: { icon: 'i-lucide-phone', label: 'Bellen' }
+}
+
+/**
+ * Get metadata (icon and default label) for a contact method type
+ */
+export function useContactMeta() {
+  function getMeta(type: ContactMethodType): ContactMeta {
+    return contactMeta[type] ?? { icon: 'i-lucide-link', label: 'Contact' }
+  }
+
+  function getIcon(type: ContactMethodType): string {
+    return getMeta(type).icon
+  }
+
+  function getLabel(type: ContactMethodType): string {
+    return getMeta(type).label
+  }
+
+  return {
+    getMeta,
+    getIcon,
+    getLabel
+  }
+}

--- a/app/data/profiles.ts
+++ b/app/data/profiles.ts
@@ -4,7 +4,7 @@ export const profiles: Profile[] = [
   {
     name: 'Marcel',
     slug: 'marcel',
-    descriptor: 'Senior Software Engineer',
+    descriptor: 'Full-Stack Developer',
     contacts: [
       { type: 'website', url: 'https://marcel.tuinstra.dev' },
       { type: 'linkedin', url: 'https://www.linkedin.com/in/marcel-tuinstra-6a98895a/' },

--- a/app/data/profiles.ts
+++ b/app/data/profiles.ts
@@ -4,10 +4,10 @@ export const profiles: Profile[] = [
   {
     name: 'Marcel',
     slug: 'marcel',
-    descriptor: 'Developer & Designer',
+    descriptor: 'Senior Software Engineer',
     contacts: [
       { type: 'website', url: 'https://marcel.tuinstra.dev' },
-      { type: 'linkedin', url: 'https://linkedin.com/in/marceltuinstra' },
+      { type: 'linkedin', url: 'https://www.linkedin.com/in/marcel-tuinstra-6a98895a/' },
       { type: 'github', url: 'https://github.com/marcel-tuinstra' },
       { type: 'email', url: 'mailto:marcel@tuinstra.dev' }
     ]
@@ -15,11 +15,10 @@ export const profiles: Profile[] = [
   {
     name: 'Daan',
     slug: 'daan',
-    descriptor: 'Developer & Gamer',
+    descriptor: 'Lecturer CMGT / Researcher XR',
     contacts: [
-      { type: 'linkedin', url: 'https://linkedin.com/in/daantuinstra' },
-      { type: 'github', url: 'https://github.com/daantuinstra' },
-      { type: 'email', url: 'mailto:daan@tuinstra.dev' }
+      { type: 'linkedin', url: 'https://www.linkedin.com/in/daan-tuinstra-24660210a/' },
+      { type: 'email', url: 'mailto:daantuinstra@hotmail.com' }
     ]
   }
 ]

--- a/app/pages/[slug].vue
+++ b/app/pages/[slug].vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { profiles } from '~/data/profiles'
+
+const route = useRoute()
+const slug = computed(() => route.params.slug as string)
+
+const profileData = computed(() => profiles.find(p => p.slug === slug.value))
+
+// Handle 404 for unknown profiles
+if (!profileData.value) {
+  throw createError({
+    statusCode: 404,
+    statusMessage: 'Profiel niet gevonden'
+  })
+}
+
+// Non-null assertion after 404 check - profile is guaranteed to exist
+const profile = profileData.value
+
+// Set page meta
+useHead({
+  title: `${profile.name} Tuinstra`
+})
+
+useSeoMeta({
+  title: `${profile.name} Tuinstra`,
+  description: profile.descriptor
+})
+</script>
+
+<template>
+  <div class="flex min-h-screen items-center justify-center px-4 py-8">
+    <div class="w-full max-w-md space-y-8">
+      <!-- Back navigation -->
+      <NuxtLink
+        to="/"
+        class="inline-flex items-center gap-1 text-sm text-muted hover:text-default transition-colors"
+      >
+        <UIcon
+          name="i-lucide-arrow-left"
+          class="size-4"
+        />
+        Terug naar overzicht
+      </NuxtLink>
+
+      <!-- Profile card -->
+      <UCard>
+        <div class="space-y-6">
+          <!-- Header -->
+          <header class="text-center space-y-2">
+            <h1 class="text-3xl font-bold tracking-tight">
+              {{ profile.name }} Tuinstra
+            </h1>
+            <p class="text-lg text-muted">
+              {{ profile.descriptor }}
+            </p>
+            <p
+              v-if="profile.bio"
+              class="text-sm text-muted"
+            >
+              {{ profile.bio }}
+            </p>
+          </header>
+
+          <!-- Contact methods -->
+          <nav
+            class="space-y-3"
+            aria-label="Contactmethoden"
+          >
+            <ContactButton
+              v-for="contact in profile.contacts"
+              :key="contact.type"
+              :contact="contact"
+            />
+          </nav>
+        </div>
+      </UCard>
+    </div>
+  </div>
+</template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -12,7 +12,9 @@ export default defineNuxtConfig({
   css: ['~/assets/css/main.css'],
 
   routeRules: {
-    '/': { prerender: true }
+    '/': { prerender: true },
+    '/marcel': { prerender: true },
+    '/daan': { prerender: true }
   },
 
   compatibilityDate: '2025-01-15',


### PR DESCRIPTION
## Summary
- Add digital business card pages at `/marcel` and `/daan`
- Each profile page displays contact methods with icons (LinkedIn, GitHub, email, website)
- Hub cards now link internally to profile pages instead of external URLs
- Mobile-first, responsive design with accessible navigation

## New Files
- `app/composables/useContactMeta.ts` - Icon/label mapping for contact types
- `app/components/ContactButton.vue` - Reusable contact button with icon
- `app/pages/[slug].vue` - Dynamic profile page template

## Flow
```
tuinstra.dev (hub)
    ↓ Click "Marcel"
/marcel (business card)
    ↓ Click contact
External (LinkedIn, website, etc.)
```

## Profile Data Updated
- **Marcel**: Senior Software Engineer (website, LinkedIn, GitHub, email)
- **Daan**: Lecturer CMGT / Researcher XR (LinkedIn, email)

## Shortcut
https://app.shortcut.com/tuinstradev/story/181