### PR TITLE
fix: regenerate package-lock.json to sync with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8173,17 +8173,6 @@
       "integrity": "sha512-Z3UPUKasUVDFCDYAjP2fmlVRf1jFHJv1izAmPjiOa0OCIw1W7iC8PZ2GsoDa8uZv+mKyWopxxStT9q05+27h7w==",
       "license": "Apache-2.0"
     },
-    "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/comment-parser": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
@@ -8867,6 +8856,16 @@
       "bin": {
         "editorconfig": "bin/editorconfig"
       },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       }


### PR DESCRIPTION
## Summary
Fixes the failing deploy workflow by regenerating `package-lock.json`.

## Problem
Docker build was failing because `npm ci` found mismatched versions:
- Lock file had `commander@10.0.1`
- Package.json required `commander@13.1.0`

## Solution
Regenerated the lock file with `npm install` to sync all dependencies.

## Workflow
Fixes: https://github.com/marcel-tuinstra/site-tuinstra/actions/runs/21803419840