### PR TITLE
feat[SC-175] Visual identity baseline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci
+RUN npm ci || npm install
 
 COPY . .
 RUN npm run generate

--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -1,3 +1,21 @@
+/**
+ * Design Tokens for tuinstra.dev
+ *
+ * Typography:
+ * - Font: JetBrains Mono (monospace) - configured in main.css via @fontsource
+ * - Developer aesthetic with consistent monospace throughout
+ *
+ * Color Palette:
+ * - Primary: Blue - used for interactive elements and accents
+ * - Neutral: Zinc - used for text, backgrounds, and borders
+ * - Both profiles use the same color scheme (no differentiation)
+ *
+ * Avatar Style:
+ * - Source: GitHub profile photos (github.com/{username}.png)
+ * - Shape: Rounded square (rounded-lg class)
+ * - Size: 3xl on cards and profile pages
+ * - Fallback: Initials via UAvatar alt prop
+ */
 export default defineAppConfig({
   ui: {
     colors: {

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,2 +1,12 @@
 @import "tailwindcss";
 @import "@nuxt/ui";
+
+/* JetBrains Mono - Primary font for developer aesthetic */
+@import "@fontsource/jetbrains-mono/400.css";
+@import "@fontsource/jetbrains-mono/500.css";
+@import "@fontsource/jetbrains-mono/700.css";
+
+/* Apply JetBrains Mono as default font */
+@theme {
+  --font-sans: "JetBrains Mono", ui-monospace, monospace;
+}

--- a/app/components/ProfileCard.vue
+++ b/app/components/ProfileCard.vue
@@ -11,13 +11,21 @@ defineProps<{
     :to="`/${profile.slug}`"
     class="text-center hover:ring-2 hover:ring-primary transition-all cursor-pointer"
   >
-    <div class="space-y-3">
-      <h2 class="text-2xl font-bold">
-        {{ profile.name }}
-      </h2>
-      <p class="text-muted">
-        {{ profile.descriptor }}
-      </p>
+    <div class="space-y-4">
+      <UAvatar
+        :src="profile.avatarUrl"
+        :alt="profile.name"
+        size="3xl"
+        class="mx-auto rounded-lg"
+      />
+      <div class="space-y-1">
+        <h2 class="text-2xl font-bold">
+          {{ profile.name }}
+        </h2>
+        <p class="text-muted">
+          {{ profile.descriptor }}
+        </p>
+      </div>
       <UButton
         :to="`/${profile.slug}`"
         label="Bekijk profiel"

--- a/app/data/profiles.ts
+++ b/app/data/profiles.ts
@@ -5,6 +5,7 @@ export const profiles: Profile[] = [
     name: 'Marcel',
     slug: 'marcel',
     descriptor: 'Full-Stack Developer',
+    avatarUrl: 'https://github.com/marcel-tuinstra.png',
     contacts: [
       { type: 'website', url: 'https://marcel.tuinstra.dev' },
       { type: 'linkedin', url: 'https://www.linkedin.com/in/marcel-tuinstra-6a98895a/' },
@@ -16,8 +17,10 @@ export const profiles: Profile[] = [
     name: 'Daan',
     slug: 'daan',
     descriptor: 'Lecturer CMGT / Researcher XR',
+    avatarUrl: 'https://github.com/SkyKingdom.png',
     contacts: [
       { type: 'linkedin', url: 'https://www.linkedin.com/in/daan-tuinstra-24660210a/' },
+      { type: 'github', url: 'https://github.com/SkyKingdom' },
       { type: 'email', url: 'mailto:daantuinstra@hotmail.com' }
     ]
   }

--- a/app/pages/[slug].vue
+++ b/app/pages/[slug].vue
@@ -47,19 +47,27 @@ useSeoMeta({
       <UCard>
         <div class="space-y-6">
           <!-- Header -->
-          <header class="text-center space-y-2">
-            <h1 class="text-3xl font-bold tracking-tight">
-              {{ profile.name }} Tuinstra
-            </h1>
-            <p class="text-lg text-muted">
-              {{ profile.descriptor }}
-            </p>
-            <p
-              v-if="profile.bio"
-              class="text-sm text-muted"
-            >
-              {{ profile.bio }}
-            </p>
+          <header class="text-center space-y-4">
+            <UAvatar
+              :src="profile.avatarUrl"
+              :alt="profile.name"
+              size="3xl"
+              class="mx-auto rounded-lg"
+            />
+            <div class="space-y-1">
+              <h1 class="text-3xl font-bold tracking-tight">
+                {{ profile.name }} Tuinstra
+              </h1>
+              <p class="text-lg text-muted">
+                {{ profile.descriptor }}
+              </p>
+              <p
+                v-if="profile.bio"
+                class="text-sm text-muted"
+              >
+                {{ profile.bio }}
+              </p>
+            </div>
           </header>
 
           <!-- Contact methods -->

--- a/app/types/profile.ts
+++ b/app/types/profile.ts
@@ -18,6 +18,8 @@ export interface Profile {
   slug: string
   /** Short descriptor / role */
   descriptor: string
+  /** Avatar image URL (typically GitHub profile photo) */
+  avatarUrl: string
   /** Optional bio / tagline for the business card */
   bio?: string
   /** Contact methods displayed in order (all optional) */

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "site-tuinstra",
       "hasInstallScript": true,
       "dependencies": {
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "@iconify-json/lucide": "^1.2.87",
         "@iconify-json/simple-icons": "^1.2.68",
         "@nuxt/ui": "^4.4.0",
@@ -1382,6 +1383,15 @@
         "@vue/composition-api": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "@iconify-json/lucide": "^1.2.87",
     "@iconify-json/simple-icons": "^1.2.68",
     "@nuxt/ui": "^4.4.0",

--- a/tests/unit/profiles.test.ts
+++ b/tests/unit/profiles.test.ts
@@ -22,8 +22,15 @@ describe('profiles data', () => {
       expect(profile.name).toBeTruthy()
       expect(profile.slug).toBeTruthy()
       expect(profile.descriptor).toBeTruthy()
+      expect(profile.avatarUrl).toBeTruthy()
       expect(profile.contacts).toBeInstanceOf(Array)
       expect(profile.contacts.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('should have valid avatar URLs from GitHub', () => {
+    for (const profile of profiles) {
+      expect(profile.avatarUrl).toMatch(/^https:\/\/github\.com\/[\w-]+\.png$/)
     }
   })
 


### PR DESCRIPTION
## Summary
- Add JetBrains Mono as the primary monospace font for developer aesthetic
- Add GitHub avatars to profiles with `avatarUrl` property and `UAvatar` components
- Document design tokens in `app.config.ts`
- Add Daan's GitHub contact method

## Changes
- **Font**: JetBrains Mono via `@fontsource/jetbrains-mono`
- **Avatars**: Rounded-lg style using GitHub profile photos
- **Profile type**: Added `avatarUrl` property
- **Components**: Updated `ProfileCard.vue` and `[slug].vue` with `UAvatar`
- **Dockerfile**: Fixed `npm ci` fallback for compatibility
- **Tests**: Added avatar URL validation tests

## Shortcut
[SC-175](https://app.shortcut.com/tuinstra/story/175)