### PR TITLE
feat[SC-185] SEO setup: sitemap, robots.txt, and meta tags

### DIFF
--- a/app/pages/[slug].vue
+++ b/app/pages/[slug].vue
@@ -17,14 +17,29 @@ if (!profileData.value) {
 // Non-null assertion after 404 check - profile is guaranteed to exist
 const profile = profileData.value
 
-// Set page meta
+// SEO metadata for profile page
+const pageTitle = `${profile.name} Tuinstra — ${profile.descriptor}`
+const pageDescription = `${profile.name} Tuinstra — ${profile.descriptor}. Neem contact op via de beschikbare kanalen.`
+const pageUrl = `https://tuinstra.dev/${profile.slug}`
+
 useHead({
-  title: `${profile.name} Tuinstra`
+  title: pageTitle,
+  link: [
+    { rel: 'canonical', href: pageUrl }
+  ]
 })
 
 useSeoMeta({
-  title: `${profile.name} Tuinstra`,
-  description: profile.descriptor
+  title: pageTitle,
+  description: pageDescription,
+  ogTitle: pageTitle,
+  ogDescription: pageDescription,
+  ogType: 'profile',
+  ogUrl: pageUrl,
+  ogSiteName: 'Tuinstra.dev',
+  twitterCard: 'summary',
+  twitterTitle: pageTitle,
+  twitterDescription: pageDescription
 })
 </script>
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,5 +1,26 @@
 <script setup lang="ts">
 import { profiles } from '~/data/profiles'
+
+// SEO metadata for hub page
+useHead({
+  title: 'Tuinstra.dev',
+  link: [
+    { rel: 'canonical', href: 'https://tuinstra.dev/' }
+  ]
+})
+
+useSeoMeta({
+  title: 'Tuinstra.dev',
+  description: 'Familie Tuinstra — kies het juiste profiel. Vind Marcel (Full-Stack Developer) of Daan (Lecturer CMGT / Researcher XR).',
+  ogTitle: 'Tuinstra.dev',
+  ogDescription: 'Familie Tuinstra — kies het juiste profiel',
+  ogType: 'website',
+  ogUrl: 'https://tuinstra.dev/',
+  ogSiteName: 'Tuinstra.dev',
+  twitterCard: 'summary',
+  twitterTitle: 'Tuinstra.dev',
+  twitterDescription: 'Familie Tuinstra — kies het juiste profiel'
+})
 </script>
 
 <template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,11 +2,29 @@
 export default defineNuxtConfig({
   modules: [
     '@nuxt/eslint',
-    '@nuxt/ui'
+    '@nuxt/ui',
+    '@nuxtjs/sitemap',
+    '@nuxtjs/robots'
   ],
+
+  // Site configuration for SEO modules
+  $production: {
+    site: {
+      url: 'https://tuinstra.dev'
+    }
+  },
 
   devtools: {
     enabled: true
+  },
+
+  // Global app configuration
+  app: {
+    head: {
+      htmlAttrs: {
+        lang: 'nl'
+      }
+    }
   },
 
   css: ['~/assets/css/main.css'],
@@ -26,5 +44,10 @@ export default defineNuxtConfig({
         braceStyle: '1tbs'
       }
     }
+  },
+
+  // Robots.txt configuration
+  robots: {
+    sitemap: '/sitemap.xml'
   }
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,10 @@
         "@iconify-json/lucide": "^1.2.87",
         "@iconify-json/simple-icons": "^1.2.68",
         "@nuxt/ui": "^4.4.0",
+        "@nuxtjs/robots": "^5.7.0",
+        "@nuxtjs/sitemap": "^7.6.0",
         "nuxt": "^4.3.0",
+        "nuxt-site-config": "^3.2.19",
         "tailwindcss": "^4.1.18"
       },
       "devDependencies": {
@@ -1320,6 +1323,12 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@fingerprintjs/botd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fingerprintjs/botd/-/botd-2.0.0.tgz",
+      "integrity": "sha512-yhuz23NKEcBDTHmGz/ULrXlGnbHenO+xZmVwuBkuqHUkqvaZ5TAA0kAgcRy4Wyo5dIBdkIf57UXX8/c9UlMLJg==",
+      "license": "MIT"
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.4",
@@ -3192,6 +3201,86 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/@nuxtjs/robots": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/robots/-/robots-5.7.0.tgz",
+      "integrity": "sha512-pkGtOP88rzIalvYE3rTCkJ+f0TDHfB/sbSCcA7inVemFa17JVu8AFlO4e+y4zthj+Jh98Tkf7yCuaDU5w3C1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fingerprintjs/botd": "^2.0.0",
+        "@nuxt/devtools-kit": "^3.1.1",
+        "@nuxt/kit": "^4.3.0",
+        "consola": "^3.4.2",
+        "defu": "^6.1.4",
+        "h3": "^1.15.5",
+        "nuxt-site-config": "^3.2.18",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.3.0",
+        "sirv": "^3.0.2",
+        "std-env": "^3.10.0",
+        "ufo": "^1.6.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "zod": ">=3"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nuxtjs/sitemap": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/sitemap/-/sitemap-7.6.0.tgz",
+      "integrity": "sha512-JuWwAFn9MDHWFO5C7lpV6DS86ZIrJItGfzCK1kN9WvgvDmTgal3xbfGCADmAaCWOVl2+dcPGHH6BCypQvUX0aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/devtools-kit": "^3.1.1",
+        "@nuxt/kit": "^4.3.0",
+        "chalk": "^5.6.2",
+        "defu": "^6.1.4",
+        "fast-xml-parser": "^5.3.3",
+        "nuxt-site-config": "^3.2.18",
+        "ofetch": "^1.5.1",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.3.0",
+        "radix3": "^1.1.2",
+        "semver": "^7.7.3",
+        "sirv": "^3.0.2",
+        "std-env": "^3.10.0",
+        "ufo": "^1.6.3",
+        "ultrahtml": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "zod": ">=3"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nuxtjs/sitemap/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
     },
     "node_modules/@one-ini/wasm": {
       "version": "0.1.1",
@@ -9876,6 +9965,24 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/fast-xml-parser": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.5.tgz",
+      "integrity": "sha512-JeaA2Vm9ffQKp9VjvfzObuMCjUYAp5WDYhRYL5LrBPY/jUDlUtOvDfot0vKSkB9tuX885BDHjtw4fZadD95wnA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -12814,6 +12921,42 @@
         }
       }
     },
+    "node_modules/nuxt-site-config": {
+      "version": "3.2.19",
+      "resolved": "https://registry.npmjs.org/nuxt-site-config/-/nuxt-site-config-3.2.19.tgz",
+      "integrity": "sha512-OUGfo8aJWbymheyb9S2u78ADX73C9qBf8u6BwEJiM82JBhvJTEduJBMlK8MWeh3x9NF+/YX4AYsY5hjfQE5jGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/devtools-kit": "^3.1.1",
+        "@nuxt/kit": "^4.3.0",
+        "h3": "^1.15.5",
+        "nuxt-site-config-kit": "3.2.19",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.3.0",
+        "sirv": "^3.0.2",
+        "site-config-stack": "3.2.19",
+        "ufo": "^1.6.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
+    "node_modules/nuxt-site-config-kit": {
+      "version": "3.2.19",
+      "resolved": "https://registry.npmjs.org/nuxt-site-config-kit/-/nuxt-site-config-kit-3.2.19.tgz",
+      "integrity": "sha512-5L9Dgw+QGnTLhVO7Km2oZU+wWllvNXLAFXUiZMX1dt37FKXX6v95ZKCVlFfnkSHQ+I2lmuUhFUpuORkOoVnU+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/kit": "^4.3.0",
+        "pkg-types": "^2.3.0",
+        "site-config-stack": "3.2.19",
+        "std-env": "^3.10.0",
+        "ufo": "^1.6.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
     "node_modules/nuxt/node_modules/cookie-es": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.0.tgz",
@@ -14786,6 +14929,21 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/site-config-stack": {
+      "version": "3.2.19",
+      "resolved": "https://registry.npmjs.org/site-config-stack/-/site-config-stack-3.2.19.tgz",
+      "integrity": "sha512-DJLEbH3WePmwdSDUCKCZTCc6xvY/Uuy3Qk5YG+5z5W7yMQbfRHRlEYhJbh4E431/V4aMROXH8lw5x8ETB71Nig==",
+      "license": "MIT",
+      "dependencies": {
+        "ufo": "^1.6.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "vue": "^3"
+      }
+    },
     "node_modules/slash": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -15053,6 +15211,18 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/structured-clone-es": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "@iconify-json/lucide": "^1.2.87",
     "@iconify-json/simple-icons": "^1.2.68",
     "@nuxt/ui": "^4.4.0",
+    "@nuxtjs/robots": "^5.7.0",
+    "@nuxtjs/sitemap": "^7.6.0",
     "nuxt": "^4.3.0",
+    "nuxt-site-config": "^3.2.19",
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Add automatic sitemap.xml and robots.txt generation
- Add comprehensive SEO meta tags to all pages
- Configure site for proper search engine indexing

## Changes

### New Dependencies
- `@nuxtjs/sitemap` - Automatic sitemap.xml generation from routes
- `@nuxtjs/robots` - robots.txt with sitemap reference

### Configuration (`nuxt.config.ts`)
- Added sitemap and robots modules
- Configured production site URL (`https://tuinstra.dev`)
- Set HTML lang attribute to `nl`
- Robots.txt points to `/sitemap.xml`

### Hub Page (`index.vue`)
- Title: "Tuinstra.dev"
- Description with both profiles mentioned
- OG and Twitter card meta tags
- Canonical URL

### Profile Pages (`[slug].vue`)
- Dynamic title with name and descriptor
- Dynamic description
- OG type set to "profile"
- Canonical URL per profile

## Verification
After deployment, verify:
- `/sitemap.xml` contains all routes (/, /marcel, /daan)
- `/robots.txt` is valid and references sitemap
- Meta tags visible in page source

## Shortcut
[SC-185](https://app.shortcut.com/tuinstra/story/185)