### PR TITLE
release: 2026-02-09

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Go to '...'
+        2. Run '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, or logs.

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,36 @@
+name: Chore
+description: Maintenance task, refactoring, or documentation update
+labels: ["chore"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for maintenance tasks, refactoring, or documentation updates.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs to be done?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      options:
+        - Refactoring
+        - Documentation
+        - Dependency update
+        - CI/CD improvement
+        - Cleanup
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context or details.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Shortcut Stories
+    url: https://app.shortcut.com/tuinstradev
+    about: For tracked work, create stories in Shortcut instead.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe what you'd like to see.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you've considered?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context, mockups, or examples.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,17 @@
+## Status
+
+[![CI](../../actions/workflows/pr-checks.yml/badge.svg)](../../actions/workflows/pr-checks.yml)
+
 ## Summary
 
-<!-- Brief description of the changes -->
-
-## Shortcut Story
-
-<!-- Link to the Shortcut story -->
-
-## Changes
-
-- 
+<!-- Describe what this PR changes and why -->
 
 ## Checklist
 
 - [ ] `make lint` passes
 - [ ] `make test` passes
 - [ ] PR title follows format: `<type>[SC-<id>] <title>`
+
+## Shortcut
+
+<!-- Link to Shortcut story: https://app.shortcut.com/tuinstradev/story/XXX -->

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,0 +1,10 @@
+name: CI Docker
+
+on:
+  pull_request:
+
+jobs:
+  docker-scan:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-ci-docker.yml@v1
+    with:
+      dockerfile: Dockerfile

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,0 +1,14 @@
+name: CI Docker
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  docker-scan:
+    uses: marcel-tuinstra/devops/.github/workflows/reusable-ci-docker.yml@v1
+    with:
+      dockerfile: Dockerfile

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   packages: write
+  security-events: write
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   packages: write
+  security-events: write
 
 jobs:
   deploy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Create Release PR
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          date=$(date +%Y-%m-%d)
+          base_title="release: ${date}"
+
+          # Check if a release PR already exists for today
+          existing=$(gh pr list --base main --head develop --search "${base_title}" --json number --jq 'length')
+          if [[ "$existing" -gt 0 ]]; then
+            # Append counter
+            count=$((existing + 1))
+            title="${base_title}.${count}"
+          else
+            title="${base_title}"
+          fi
+
+          # Generate changelog: commits on develop not yet in main
+          changelog=$(git log origin/main..origin/develop --oneline --no-merges --format="- %s" || echo "- No new commits")
+
+          # Check if there are actually changes to release
+          if [[ -z "$(git log origin/main..origin/develop --oneline)" ]]; then
+            echo "No changes to release — develop and main are in sync."
+            exit 0
+          fi
+
+          gh pr create \
+            --base main \
+            --head develop \
+            --title "${title}" \
+            --body "## ${title}
+
+          ### Changes
+
+          ${changelog}
+          "
+
+          echo "Release PR created: ${title}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN apk upgrade --no-cache
 
 COPY package*.json ./
-RUN npm ci
+RUN npm ci || npm install
 
 COPY . .
 RUN npm run generate

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,17 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 
 COPY . .
 RUN npm run generate
 
 FROM nginx:1.27-alpine
+RUN apk add --no-cache curl
 COPY --from=builder /app/.output/public /usr/share/nginx/html
 EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:80/health || exit 1
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:22-alpine AS builder
 WORKDIR /app
 
+# Update base image packages for security patches
+RUN apk upgrade --no-cache
+
 COPY package*.json ./
 RUN npm ci
 
@@ -8,7 +11,10 @@ COPY . .
 RUN npm run generate
 
 FROM nginx:1.27-alpine
-RUN apk add --no-cache curl
+
+# Update base image packages for security patches
+RUN apk upgrade --no-cache && apk add --no-cache curl
+
 COPY --from=builder /app/.output/public /usr/share/nginx/html
 EXPOSE 80
 

--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -1,3 +1,21 @@
+/**
+ * Design Tokens for tuinstra.dev
+ *
+ * Typography:
+ * - Font: JetBrains Mono (monospace) - configured in main.css via @fontsource
+ * - Developer aesthetic with consistent monospace throughout
+ *
+ * Color Palette:
+ * - Primary: Blue - used for interactive elements and accents
+ * - Neutral: Zinc - used for text, backgrounds, and borders
+ * - Both profiles use the same color scheme (no differentiation)
+ *
+ * Avatar Style:
+ * - Source: GitHub profile photos (github.com/{username}.png)
+ * - Shape: Rounded square (rounded-lg class)
+ * - Size: 3xl on cards and profile pages
+ * - Fallback: Initials via UAvatar alt prop
+ */
 export default defineAppConfig({
   ui: {
     colors: {

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,2 +1,12 @@
 @import "tailwindcss";
 @import "@nuxt/ui";
+
+/* JetBrains Mono - Primary font for developer aesthetic */
+@import "@fontsource/jetbrains-mono/400.css";
+@import "@fontsource/jetbrains-mono/500.css";
+@import "@fontsource/jetbrains-mono/700.css";
+
+/* Apply JetBrains Mono as default font */
+@theme {
+  --font-sans: "JetBrains Mono", ui-monospace, monospace;
+}

--- a/app/components/ContactButton.vue
+++ b/app/components/ContactButton.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import type { ContactMethod } from '~/types/profile'
+import { useContactMeta } from '~/composables/useContactMeta'
+
+const props = defineProps<{
+  contact: ContactMethod
+}>()
+
+const { getMeta } = useContactMeta()
+
+const meta = computed(() => getMeta(props.contact.type))
+const label = computed(() => props.contact.label ?? meta.value.label)
+const icon = computed(() => meta.value.icon)
+
+/** Determine if contact opens externally */
+const isExternal = computed(() => {
+  return props.contact.type !== 'email' && props.contact.type !== 'phone'
+})
+</script>
+
+<template>
+  <UButton
+    :to="contact.url"
+    :icon="icon"
+    :label="label"
+    :target="isExternal ? '_blank' : undefined"
+    variant="outline"
+    color="neutral"
+    size="xl"
+    block
+    class="justify-start"
+  />
+</template>

--- a/app/components/ProfileCard.vue
+++ b/app/components/ProfileCard.vue
@@ -7,23 +7,37 @@ defineProps<{
 </script>
 
 <template>
-  <UCard
+  <NuxtLink
     :to="`/${profile.slug}`"
-    class="text-center hover:ring-2 hover:ring-primary transition-all cursor-pointer"
+    class="block group"
   >
-    <div class="space-y-3">
-      <h2 class="text-2xl font-bold">
-        {{ profile.name }}
-      </h2>
-      <p class="text-muted">
-        {{ profile.descriptor }}
-      </p>
-      <UButton
-        :to="`/${profile.slug}`"
-        label="Bekijk profiel"
-        size="lg"
-        trailing-icon="i-lucide-arrow-right"
-      />
-    </div>
-  </UCard>
+    <UCard
+      class="h-full text-center transition-all duration-200
+             group-hover:ring-2 group-hover:ring-primary group-hover:shadow-lg
+             group-focus-visible:ring-2 group-focus-visible:ring-primary group-focus-visible:ring-offset-2
+             group-active:scale-[0.98]"
+    >
+      <div class="space-y-4 py-2">
+        <div class="space-y-2">
+          <h2 class="text-2xl font-bold tracking-tight">
+            {{ profile.name }} Tuinstra
+          </h2>
+          <p class="text-muted">
+            {{ profile.descriptor }}
+          </p>
+        </div>
+        <div
+          class="inline-flex items-center gap-2 text-primary font-medium
+                 group-hover:gap-3 transition-all duration-200"
+          aria-hidden="true"
+        >
+          <span>Bekijk profiel</span>
+          <UIcon
+            name="i-lucide-arrow-right"
+            class="size-5"
+          />
+        </div>
+      </div>
+    </UCard>
+  </NuxtLink>
 </template>

--- a/app/components/ProfileCard.vue
+++ b/app/components/ProfileCard.vue
@@ -11,13 +11,21 @@ defineProps<{
     :to="`/${profile.slug}`"
     class="text-center hover:ring-2 hover:ring-primary transition-all cursor-pointer"
   >
-    <div class="space-y-3">
-      <h2 class="text-2xl font-bold">
-        {{ profile.name }}
-      </h2>
-      <p class="text-muted">
-        {{ profile.descriptor }}
-      </p>
+    <div class="space-y-4">
+      <UAvatar
+        :src="profile.avatarUrl"
+        :alt="profile.name"
+        size="3xl"
+        class="mx-auto rounded-lg"
+      />
+      <div class="space-y-1">
+        <h2 class="text-2xl font-bold">
+          {{ profile.name }}
+        </h2>
+        <p class="text-muted">
+          {{ profile.descriptor }}
+        </p>
+      </div>
       <UButton
         :to="`/${profile.slug}`"
         label="Bekijk profiel"

--- a/app/components/ProfileCard.vue
+++ b/app/components/ProfileCard.vue
@@ -1,28 +1,16 @@
 <script setup lang="ts">
 import type { Profile } from '~/types/profile'
 
-const props = defineProps<{
+defineProps<{
   profile: Profile
 }>()
-
-/** Get the primary contact (first in array) for the CTA */
-const primaryContact = computed(() => props.profile.contacts[0])
-
-/** Generate a display label for a contact type */
-function getContactLabel(type: string): string {
-  const labels: Record<string, string> = {
-    website: 'Bekijk website',
-    linkedin: 'LinkedIn',
-    github: 'GitHub',
-    email: 'E-mail',
-    phone: 'Bel'
-  }
-  return labels[type] ?? 'Contact'
-}
 </script>
 
 <template>
-  <UCard class="text-center">
+  <UCard
+    :to="`/${profile.slug}`"
+    class="text-center hover:ring-2 hover:ring-primary transition-all cursor-pointer"
+  >
     <div class="space-y-3">
       <h2 class="text-2xl font-bold">
         {{ profile.name }}
@@ -31,11 +19,10 @@ function getContactLabel(type: string): string {
         {{ profile.descriptor }}
       </p>
       <UButton
-        v-if="primaryContact"
-        :to="primaryContact.url"
-        :label="primaryContact.label ?? getContactLabel(primaryContact.type)"
-        target="_blank"
+        :to="`/${profile.slug}`"
+        label="Bekijk profiel"
         size="lg"
+        trailing-icon="i-lucide-arrow-right"
       />
     </div>
   </UCard>

--- a/app/components/ProfileCard.vue
+++ b/app/components/ProfileCard.vue
@@ -1,9 +1,24 @@
 <script setup lang="ts">
 import type { Profile } from '~/types/profile'
 
-defineProps<{
+const props = defineProps<{
   profile: Profile
 }>()
+
+/** Get the primary contact (first in array) for the CTA */
+const primaryContact = computed(() => props.profile.contacts[0])
+
+/** Generate a display label for a contact type */
+function getContactLabel(type: string): string {
+  const labels: Record<string, string> = {
+    website: 'Bekijk website',
+    linkedin: 'LinkedIn',
+    github: 'GitHub',
+    email: 'E-mail',
+    phone: 'Bel'
+  }
+  return labels[type] ?? 'Contact'
+}
 </script>
 
 <template>
@@ -16,8 +31,9 @@ defineProps<{
         {{ profile.descriptor }}
       </p>
       <UButton
-        :to="profile.ctaLink"
-        :label="profile.ctaLabel"
+        v-if="primaryContact"
+        :to="primaryContact.url"
+        :label="primaryContact.label ?? getContactLabel(primaryContact.type)"
         target="_blank"
         size="lg"
       />

--- a/app/composables/useContactMeta.ts
+++ b/app/composables/useContactMeta.ts
@@ -1,0 +1,37 @@
+import type { ContactMethodType } from '~/types/profile'
+
+export interface ContactMeta {
+  icon: string
+  label: string
+}
+
+const contactMeta: Record<ContactMethodType, ContactMeta> = {
+  website: { icon: 'i-lucide-globe', label: 'Website' },
+  linkedin: { icon: 'i-simple-icons-linkedin', label: 'LinkedIn' },
+  github: { icon: 'i-simple-icons-github', label: 'GitHub' },
+  email: { icon: 'i-lucide-mail', label: 'E-mail' },
+  phone: { icon: 'i-lucide-phone', label: 'Bellen' }
+}
+
+/**
+ * Get metadata (icon and default label) for a contact method type
+ */
+export function useContactMeta() {
+  function getMeta(type: ContactMethodType): ContactMeta {
+    return contactMeta[type] ?? { icon: 'i-lucide-link', label: 'Contact' }
+  }
+
+  function getIcon(type: ContactMethodType): string {
+    return getMeta(type).icon
+  }
+
+  function getLabel(type: ContactMethodType): string {
+    return getMeta(type).label
+  }
+
+  return {
+    getMeta,
+    getIcon,
+    getLabel
+  }
+}

--- a/app/data/profiles.ts
+++ b/app/data/profiles.ts
@@ -4,7 +4,7 @@ export const profiles: Profile[] = [
   {
     name: 'Marcel',
     slug: 'marcel',
-    descriptor: 'Senior Software Engineer',
+    descriptor: 'Full-Stack Developer',
     contacts: [
       { type: 'website', url: 'https://marcel.tuinstra.dev' },
       { type: 'linkedin', url: 'https://www.linkedin.com/in/marcel-tuinstra-6a98895a/' },

--- a/app/data/profiles.ts
+++ b/app/data/profiles.ts
@@ -5,6 +5,7 @@ export const profiles: Profile[] = [
     name: 'Marcel',
     slug: 'marcel',
     descriptor: 'Full-Stack Developer',
+    avatarUrl: 'https://github.com/marcel-tuinstra.png',
     contacts: [
       { type: 'website', url: 'https://marcel.tuinstra.dev' },
       { type: 'linkedin', url: 'https://www.linkedin.com/in/marcel-tuinstra-6a98895a/' },
@@ -16,8 +17,10 @@ export const profiles: Profile[] = [
     name: 'Daan',
     slug: 'daan',
     descriptor: 'Lecturer CMGT / Researcher XR',
+    avatarUrl: 'https://github.com/SkyKingdom.png',
     contacts: [
       { type: 'linkedin', url: 'https://www.linkedin.com/in/daan-tuinstra-24660210a/' },
+      { type: 'github', url: 'https://github.com/SkyKingdom' },
       { type: 'email', url: 'mailto:daantuinstra@hotmail.com' }
     ]
   }

--- a/app/data/profiles.ts
+++ b/app/data/profiles.ts
@@ -5,14 +5,21 @@ export const profiles: Profile[] = [
     name: 'Marcel',
     slug: 'marcel',
     descriptor: 'Developer & Designer',
-    ctaLink: 'https://marcel.tuinstra.dev',
-    ctaLabel: 'Bekijk profiel'
+    contacts: [
+      { type: 'website', url: 'https://marcel.tuinstra.dev' },
+      { type: 'linkedin', url: 'https://linkedin.com/in/marceltuinstra' },
+      { type: 'github', url: 'https://github.com/marcel-tuinstra' },
+      { type: 'email', url: 'mailto:marcel@tuinstra.dev' }
+    ]
   },
   {
     name: 'Daan',
     slug: 'daan',
     descriptor: 'Developer & Gamer',
-    ctaLink: 'https://daan.tuinstra.dev',
-    ctaLabel: 'Bekijk profiel'
+    contacts: [
+      { type: 'linkedin', url: 'https://linkedin.com/in/daantuinstra' },
+      { type: 'github', url: 'https://github.com/daantuinstra' },
+      { type: 'email', url: 'mailto:daan@tuinstra.dev' }
+    ]
   }
 ]

--- a/app/data/profiles.ts
+++ b/app/data/profiles.ts
@@ -4,10 +4,10 @@ export const profiles: Profile[] = [
   {
     name: 'Marcel',
     slug: 'marcel',
-    descriptor: 'Developer & Designer',
+    descriptor: 'Senior Software Engineer',
     contacts: [
       { type: 'website', url: 'https://marcel.tuinstra.dev' },
-      { type: 'linkedin', url: 'https://linkedin.com/in/marceltuinstra' },
+      { type: 'linkedin', url: 'https://www.linkedin.com/in/marcel-tuinstra-6a98895a/' },
       { type: 'github', url: 'https://github.com/marcel-tuinstra' },
       { type: 'email', url: 'mailto:marcel@tuinstra.dev' }
     ]
@@ -15,11 +15,10 @@ export const profiles: Profile[] = [
   {
     name: 'Daan',
     slug: 'daan',
-    descriptor: 'Developer & Gamer',
+    descriptor: 'Lecturer CMGT / Researcher XR',
     contacts: [
-      { type: 'linkedin', url: 'https://linkedin.com/in/daantuinstra' },
-      { type: 'github', url: 'https://github.com/daantuinstra' },
-      { type: 'email', url: 'mailto:daan@tuinstra.dev' }
+      { type: 'linkedin', url: 'https://www.linkedin.com/in/daan-tuinstra-24660210a/' },
+      { type: 'email', url: 'mailto:daantuinstra@hotmail.com' }
     ]
   }
 ]

--- a/app/error.vue
+++ b/app/error.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { NuxtError } from '#app'
+
+defineProps<{
+  error: NuxtError
+}>()
+
+const handleError = () => clearError({ redirect: '/' })
+</script>
+
+<template>
+  <div class="flex min-h-screen items-center justify-center px-4">
+    <div class="w-full max-w-md space-y-8 text-center">
+      <header class="space-y-2">
+        <p class="text-6xl font-bold text-muted">
+          {{ error.statusCode }}
+        </p>
+        <h1 class="text-2xl font-bold tracking-tight">
+          {{ error.statusCode === 404 ? 'Pagina niet gevonden' : 'Er ging iets mis' }}
+        </h1>
+        <p class="text-muted">
+          {{ error.statusCode === 404
+            ? 'De pagina die je zoekt bestaat niet of is verplaatst.'
+            : error.message || 'Er is een onverwachte fout opgetreden.'
+          }}
+        </p>
+      </header>
+
+      <UButton
+        size="lg"
+        icon="i-lucide-arrow-left"
+        @click="handleError"
+      >
+        Terug naar hub
+      </UButton>
+    </div>
+  </div>
+</template>

--- a/app/pages/[slug].vue
+++ b/app/pages/[slug].vue
@@ -17,14 +17,29 @@ if (!profileData.value) {
 // Non-null assertion after 404 check - profile is guaranteed to exist
 const profile = profileData.value
 
-// Set page meta
+// SEO metadata for profile page
+const pageTitle = `${profile.name} Tuinstra — ${profile.descriptor}`
+const pageDescription = `${profile.name} Tuinstra — ${profile.descriptor}. Neem contact op via de beschikbare kanalen.`
+const pageUrl = `https://tuinstra.dev/${profile.slug}`
+
 useHead({
-  title: `${profile.name} Tuinstra`
+  title: pageTitle,
+  link: [
+    { rel: 'canonical', href: pageUrl }
+  ]
 })
 
 useSeoMeta({
-  title: `${profile.name} Tuinstra`,
-  description: profile.descriptor
+  title: pageTitle,
+  description: pageDescription,
+  ogTitle: pageTitle,
+  ogDescription: pageDescription,
+  ogType: 'profile',
+  ogUrl: pageUrl,
+  ogSiteName: 'Tuinstra.dev',
+  twitterCard: 'summary',
+  twitterTitle: pageTitle,
+  twitterDescription: pageDescription
 })
 </script>
 

--- a/app/pages/[slug].vue
+++ b/app/pages/[slug].vue
@@ -47,19 +47,27 @@ useSeoMeta({
       <UCard>
         <div class="space-y-6">
           <!-- Header -->
-          <header class="text-center space-y-2">
-            <h1 class="text-3xl font-bold tracking-tight">
-              {{ profile.name }} Tuinstra
-            </h1>
-            <p class="text-lg text-muted">
-              {{ profile.descriptor }}
-            </p>
-            <p
-              v-if="profile.bio"
-              class="text-sm text-muted"
-            >
-              {{ profile.bio }}
-            </p>
+          <header class="text-center space-y-4">
+            <UAvatar
+              :src="profile.avatarUrl"
+              :alt="profile.name"
+              size="3xl"
+              class="mx-auto rounded-lg"
+            />
+            <div class="space-y-1">
+              <h1 class="text-3xl font-bold tracking-tight">
+                {{ profile.name }} Tuinstra
+              </h1>
+              <p class="text-lg text-muted">
+                {{ profile.descriptor }}
+              </p>
+              <p
+                v-if="profile.bio"
+                class="text-sm text-muted"
+              >
+                {{ profile.bio }}
+              </p>
+            </div>
           </header>
 
           <!-- Contact methods -->

--- a/app/pages/[slug].vue
+++ b/app/pages/[slug].vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { profiles } from '~/data/profiles'
+
+const route = useRoute()
+const slug = computed(() => route.params.slug as string)
+
+const profileData = computed(() => profiles.find(p => p.slug === slug.value))
+
+// Handle 404 for unknown profiles
+if (!profileData.value) {
+  throw createError({
+    statusCode: 404,
+    statusMessage: 'Profiel niet gevonden'
+  })
+}
+
+// Non-null assertion after 404 check - profile is guaranteed to exist
+const profile = profileData.value
+
+// Set page meta
+useHead({
+  title: `${profile.name} Tuinstra`
+})
+
+useSeoMeta({
+  title: `${profile.name} Tuinstra`,
+  description: profile.descriptor
+})
+</script>
+
+<template>
+  <div class="flex min-h-screen items-center justify-center px-4 py-8">
+    <div class="w-full max-w-md space-y-8">
+      <!-- Back navigation -->
+      <NuxtLink
+        to="/"
+        class="inline-flex items-center gap-1 text-sm text-muted hover:text-default transition-colors"
+      >
+        <UIcon
+          name="i-lucide-arrow-left"
+          class="size-4"
+        />
+        Terug naar overzicht
+      </NuxtLink>
+
+      <!-- Profile card -->
+      <UCard>
+        <div class="space-y-6">
+          <!-- Header -->
+          <header class="text-center space-y-2">
+            <h1 class="text-3xl font-bold tracking-tight">
+              {{ profile.name }} Tuinstra
+            </h1>
+            <p class="text-lg text-muted">
+              {{ profile.descriptor }}
+            </p>
+            <p
+              v-if="profile.bio"
+              class="text-sm text-muted"
+            >
+              {{ profile.bio }}
+            </p>
+          </header>
+
+          <!-- Contact methods -->
+          <nav
+            class="space-y-3"
+            aria-label="Contactmethoden"
+          >
+            <ContactButton
+              v-for="contact in profile.contacts"
+              :key="contact.type"
+              :contact="contact"
+            />
+          </nav>
+        </div>
+      </UCard>
+    </div>
+  </div>
+</template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,5 +1,26 @@
 <script setup lang="ts">
 import { profiles } from '~/data/profiles'
+
+// SEO metadata for hub page
+useHead({
+  title: 'Tuinstra.dev',
+  link: [
+    { rel: 'canonical', href: 'https://tuinstra.dev/' }
+  ]
+})
+
+useSeoMeta({
+  title: 'Tuinstra.dev',
+  description: 'Familie Tuinstra — kies het juiste profiel. Vind Marcel (Full-Stack Developer) of Daan (Lecturer CMGT / Researcher XR).',
+  ogTitle: 'Tuinstra.dev',
+  ogDescription: 'Familie Tuinstra — kies het juiste profiel',
+  ogType: 'website',
+  ogUrl: 'https://tuinstra.dev/',
+  ogSiteName: 'Tuinstra.dev',
+  twitterCard: 'summary',
+  twitterTitle: 'Tuinstra.dev',
+  twitterDescription: 'Familie Tuinstra — kies het juiste profiel'
+})
 </script>
 
 <template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,26 +1,46 @@
 <script setup lang="ts">
 import { profiles } from '~/data/profiles'
+
+useHead({
+  title: 'Tuinstra.dev'
+})
+
+useSeoMeta({
+  title: 'Tuinstra.dev',
+  description: 'Familie Tuinstra — kies het juiste profiel'
+})
 </script>
 
 <template>
-  <div class="flex min-h-screen items-center justify-center px-4">
-    <div class="w-full max-w-2xl space-y-8">
-      <header class="text-center">
+  <div class="flex min-h-screen items-center justify-center px-4 py-8">
+    <div class="w-full max-w-2xl space-y-10">
+      <header class="text-center space-y-4">
         <h1 class="text-4xl font-bold tracking-tight sm:text-5xl">
           Tuinstra.dev
         </h1>
-        <p class="mt-4 text-lg text-muted">
-          Wie zoek je?
+        <p class="text-lg text-muted max-w-md mx-auto">
+          Welkom bij de familie Tuinstra. Kies hieronder wie je zoekt om naar het juiste profiel te gaan.
         </p>
       </header>
 
-      <div class="grid gap-6 sm:grid-cols-2">
-        <ProfileCard
-          v-for="profile in profiles"
-          :key="profile.slug"
-          :profile="profile"
-        />
-      </div>
+      <section aria-labelledby="profile-selection">
+        <h2
+          id="profile-selection"
+          class="sr-only"
+        >
+          Kies een profiel
+        </h2>
+        <p class="text-center text-xl font-medium mb-6">
+          Wie zoek je?
+        </p>
+        <div class="grid gap-6 sm:grid-cols-2">
+          <ProfileCard
+            v-for="profile in profiles"
+            :key="profile.slug"
+            :profile="profile"
+          />
+        </div>
+      </section>
     </div>
   </div>
 </template>

--- a/app/types/profile.ts
+++ b/app/types/profile.ts
@@ -1,3 +1,16 @@
+/** Supported contact method types */
+export type ContactMethodType = 'website' | 'linkedin' | 'github' | 'email' | 'phone'
+
+/** A single contact method for a profile */
+export interface ContactMethod {
+  /** The type of contact method */
+  type: ContactMethodType
+  /** The URL or value (e.g., https://, mailto:, tel:) */
+  url: string
+  /** Optional custom label, otherwise derived from type */
+  label?: string
+}
+
 export interface Profile {
   /** Display name */
   name: string
@@ -5,8 +18,8 @@ export interface Profile {
   slug: string
   /** Short descriptor / role */
   descriptor: string
-  /** Call-to-action link (external portfolio or profile) */
-  ctaLink: string
-  /** Call-to-action label */
-  ctaLabel: string
+  /** Optional bio / tagline for the business card */
+  bio?: string
+  /** Contact methods displayed in order (all optional) */
+  contacts: ContactMethod[]
 }

--- a/app/types/profile.ts
+++ b/app/types/profile.ts
@@ -18,6 +18,8 @@ export interface Profile {
   slug: string
   /** Short descriptor / role */
   descriptor: string
+  /** Avatar image URL (typically GitHub profile photo) */
+  avatarUrl: string
   /** Optional bio / tagline for the business card */
   bio?: string
   /** Contact methods displayed in order (all optional) */

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -4,3 +4,9 @@ services:
     ports:
       - "3001:80"
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/health"]
+      interval: 30s
+      timeout: 3s
+      start_period: 5s
+      retries: 3

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -4,3 +4,9 @@ services:
     ports:
       - "3101:80"
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/health"]
+      interval: 30s
+      timeout: 3s
+      start_period: 5s
+      retries: 3

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -12,7 +12,9 @@ export default defineNuxtConfig({
   css: ['~/assets/css/main.css'],
 
   routeRules: {
-    '/': { prerender: true }
+    '/': { prerender: true },
+    '/marcel': { prerender: true },
+    '/daan': { prerender: true }
   },
 
   compatibilityDate: '2025-01-15',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,11 +2,29 @@
 export default defineNuxtConfig({
   modules: [
     '@nuxt/eslint',
-    '@nuxt/ui'
+    '@nuxt/ui',
+    '@nuxtjs/sitemap',
+    '@nuxtjs/robots'
   ],
+
+  // Site configuration for SEO modules
+  $production: {
+    site: {
+      url: 'https://tuinstra.dev'
+    }
+  },
 
   devtools: {
     enabled: true
+  },
+
+  // Global app configuration
+  app: {
+    head: {
+      htmlAttrs: {
+        lang: 'nl'
+      }
+    }
   },
 
   css: ['~/assets/css/main.css'],
@@ -26,5 +44,10 @@ export default defineNuxtConfig({
         braceStyle: '1tbs'
       }
     }
+  },
+
+  // Robots.txt configuration
+  robots: {
+    sitemap: '/sitemap.xml'
   }
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "site-tuinstra",
       "hasInstallScript": true,
       "dependencies": {
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "@iconify-json/lucide": "^1.2.87",
         "@iconify-json/simple-icons": "^1.2.68",
         "@nuxt/ui": "^4.4.0",
@@ -1355,6 +1356,15 @@
         "@vue/composition-api": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -466,31 +466,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@bomb.sh/tab": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@bomb.sh/tab/-/tab-0.0.11.tgz",
-      "integrity": "sha512-RSqyreeicYBALcMaNxIUJTBknftXsyW45VRq5gKDNwKroh0Re5SDoWwXZaphb+OTEzVdpm/BA8Uq6y0P+AtVYw==",
-      "license": "MIT",
-      "bin": {
-        "tab": "dist/bin/cli.js"
-      },
-      "peerDependencies": {
-        "cac": "^6.7.14",
-        "citty": "^0.1.6",
-        "commander": "^13.1.0"
-      },
-      "peerDependenciesMeta": {
-        "cac": {
-          "optional": true
-        },
-        "citty": {
-          "optional": true
-        },
-        "commander": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@capsizecss/unpack": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-3.0.1.tgz",
@@ -504,10 +479,9 @@
       }
     },
     "node_modules/@clack/core": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
-      "integrity": "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.0.tgz",
+      "integrity": "sha512-Orf9Ltr5NeiEuVJS8Rk2XTw3IxNC2Bic3ash7GgYeA8LJ/zmSNpSQ/m5UAhe03lA6KFgklzZ5KTHs4OAMA/SAQ==",
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.0.0",
@@ -515,13 +489,12 @@
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.11.0.tgz",
-      "integrity": "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.0.tgz",
+      "integrity": "sha512-rWPXg9UaCFqErJVQ+MecOaWsozjaxol4yjnmYcGNipAWzdaWa2x+VJmKfGq7L0APwBohQOYdHC+9RO4qRXej+A==",
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "0.5.0",
+        "@clack/core": "1.0.0",
         "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
       }
@@ -1446,18 +1419,18 @@
       }
     },
     "node_modules/@iconify-json/simple-icons": {
-      "version": "1.2.69",
-      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.69.tgz",
-      "integrity": "sha512-T/rhy5n7pzE0ZOxQVlF68SNPCYYjRBpddjgjrJO5WWVRG8es5BQmvxIE9kKF+t2hhPGvuGQFpXmUyqbOtnxirQ==",
+      "version": "1.2.70",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.70.tgz",
+      "integrity": "sha512-CYNRCgN6nBTjN4dNkrBCjHXNR2e4hQihdsZUs/afUNFOWLSYjfihca4EFN05rRvDk4Xoy2n8tym6IxBZmcn+Qg==",
       "license": "CC0-1.0",
       "dependencies": {
         "@iconify/types": "*"
       }
     },
     "node_modules/@iconify/collections": {
-      "version": "1.0.647",
-      "resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.647.tgz",
-      "integrity": "sha512-U6DSwjfDihJ5mQRoBPXNHxTqzVOKLW5AFtVLNSyAuc25Pj+IVcfLjslB9TwZS2xwSPmvdB8SPh9mxJ3kwhMTpA==",
+      "version": "1.0.648",
+      "resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.648.tgz",
+      "integrity": "sha512-0365h8NN+PXjUXc32cmaQaulext6S6Jnx1+6XxU5ivzNiQWmMlh6W1BkF9wncH+e48yzL1Tqes2A17WwYieZtw==",
       "license": "MIT",
       "dependencies": {
         "@iconify/types": "*"
@@ -1555,85 +1528,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "license": "MIT"
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -1739,6 +1633,30 @@
         "node": ">=18"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/abbrev": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^3.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
@@ -1791,37 +1709,38 @@
       }
     },
     "node_modules/@nuxt/cli": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.32.0.tgz",
-      "integrity": "sha512-n2f3SRjPlhthPvo2qWjLRRiTrUtB6WFwg0BGsvtqcqZVeQpNEU371zuKWBaFrWgqDZHV1r/aD9jrVCo+C8Pmrw==",
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.33.1.tgz",
+      "integrity": "sha512-/sCrcI0WemING9zASaXPgPDY7PrQTPlRyCXlSgGx8VwRAkWbxGaPhIc3kZQikgLwVAwy+muWVV4Wks8OTtW5Tw==",
       "license": "MIT",
       "dependencies": {
-        "@bomb.sh/tab": "^0.0.11",
-        "@clack/prompts": "1.0.0-alpha.9",
+        "@bomb.sh/tab": "^0.0.12",
+        "@clack/prompts": "^1.0.0",
         "c12": "^3.3.3",
-        "citty": "^0.1.6",
-        "confbox": "^0.2.2",
+        "citty": "^0.2.0",
+        "confbox": "^0.2.4",
         "consola": "^3.4.2",
         "copy-paste": "^2.2.0",
         "debug": "^4.4.3",
         "defu": "^6.1.4",
         "exsolve": "^1.0.8",
         "fuse.js": "^7.1.0",
-        "giget": "^2.0.0",
+        "fzf": "^0.5.2",
+        "giget": "^3.1.2",
         "jiti": "^2.6.1",
         "listhen": "^1.9.0",
-        "nypm": "^0.6.2",
+        "nypm": "^0.6.5",
         "ofetch": "^1.5.1",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
-        "perfect-debounce": "^2.0.0",
+        "perfect-debounce": "^2.1.0",
         "pkg-types": "^2.3.0",
         "scule": "^1.3.0",
-        "semver": "^7.7.3",
-        "srvx": "^0.10.0",
+        "semver": "^7.7.4",
+        "srvx": "^0.11.2",
         "std-env": "^3.10.0",
         "tinyexec": "^1.0.2",
-        "ufo": "^1.6.1",
+        "ufo": "^1.6.3",
         "youch": "^4.1.0-beta.13"
       },
       "bin": {
@@ -1832,27 +1751,66 @@
       },
       "engines": {
         "node": "^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@nuxt/schema": "^4.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@nuxt/schema": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@nuxt/cli/node_modules/@clack/core": {
-      "version": "1.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.0-alpha.7.tgz",
-      "integrity": "sha512-3vdh6Ar09D14rVxJZIm3VQJkU+ZOKKT5I5cC0cOVazy70CNyYYjiwRj9unwalhESndgxx6bGc/m6Hhs4EKF5XQ==",
+    "node_modules/@nuxt/cli/node_modules/@bomb.sh/tab": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@bomb.sh/tab/-/tab-0.0.12.tgz",
+      "integrity": "sha512-dYRwg4MqfHR5/BcTy285XOGRhjQFmNpaJBZ0tl2oU+RY595MQ5ApTF6j3OvauPAooHL6cfoOZMySQrOQztT8RQ==",
       "license": "MIT",
-      "dependencies": {
-        "picocolors": "^1.0.0",
-        "sisteransi": "^1.0.5"
+      "bin": {
+        "tab": "dist/bin/cli.js"
+      },
+      "peerDependencies": {
+        "cac": "^6.7.14",
+        "citty": "^0.1.6",
+        "commander": "^13.1.0"
+      },
+      "peerDependenciesMeta": {
+        "cac": {
+          "optional": true
+        },
+        "citty": {
+          "optional": true
+        },
+        "commander": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@nuxt/cli/node_modules/@clack/prompts": {
-      "version": "1.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.0-alpha.9.tgz",
-      "integrity": "sha512-sKs0UjiHFWvry4SiRfBi5Qnj0C/6AYx8aKkFPZQSuUZXgAram25ZDmhQmP7vj1aFyLpfHWtLQjWvOvcat0TOLg==",
+    "node_modules/@nuxt/cli/node_modules/citty": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.0.tgz",
+      "integrity": "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==",
       "license": "MIT",
-      "dependencies": {
-        "@clack/core": "1.0.0-alpha.7",
-        "picocolors": "^1.0.0",
-        "sisteransi": "^1.0.5"
+      "peer": true
+    },
+    "node_modules/@nuxt/cli/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/cli/node_modules/giget": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.1.2.tgz",
+      "integrity": "sha512-T2qUpKBHeUTwHcIhydgnJzhL0Hj785ms+JkxaaWQH9SDM/llXeewnOkfJcFShAHjWI+26hOChwUfCoupaXLm8g==",
+      "license": "MIT",
+      "bin": {
+        "giget": "dist/cli.mjs"
       }
     },
     "node_modules/@nuxt/devalue": {
@@ -1946,9 +1904,9 @@
       }
     },
     "node_modules/@nuxt/devtools/node_modules/isexe": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.2.tgz",
-      "integrity": "sha512-mIcis6w+JiQf3P7t7mg/35GKB4T1FQsBOtMIvuKw4YErj5RjtbhcTd5/I30fmkmGMwvI0WlzSNN+27K0QCMkAw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.4.tgz",
+      "integrity": "sha512-jCErc4h4RnTPjFq53G4whhjAMbUAqinGrCrTT4dmMNyi4zTthK+wphqbRLJtL4BN/Mq7Zzltr0m/b1X0m7PGFQ==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=20"
@@ -1970,19 +1928,19 @@
       }
     },
     "node_modules/@nuxt/eslint": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/eslint/-/eslint-1.13.0.tgz",
-      "integrity": "sha512-bWXTbak6XCsp86RnHKPMQ9KLBZtr91Gq6q+PquB6rpRtqcPI8+yfp90ohDCavLCAF5xVzvyfusy1Itws4yZ5IA==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/eslint/-/eslint-1.14.0.tgz",
+      "integrity": "sha512-3gSJhCYAR7AV5k2xKJwfjXbr7kvpeaJhGZQ4E45hJQnnUjLIeWPDAqHlKaYKro/pYcXQJ0sIDPJHWJbsF5Ty8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint/config-inspector": "^1.4.2",
         "@nuxt/devtools-kit": "^3.1.1",
-        "@nuxt/eslint-config": "1.13.0",
-        "@nuxt/eslint-plugin": "1.13.0",
+        "@nuxt/eslint-config": "1.14.0",
+        "@nuxt/eslint-plugin": "1.14.0",
         "@nuxt/kit": "^4.3.0",
         "chokidar": "^5.0.0",
-        "eslint-flat-config-utils": "^3.0.0",
+        "eslint-flat-config-utils": "^3.0.1",
         "eslint-typegen": "^2.3.0",
         "find-up": "^8.0.0",
         "get-port-please": "^3.2.0",
@@ -2005,30 +1963,30 @@
       }
     },
     "node_modules/@nuxt/eslint-config": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/eslint-config/-/eslint-config-1.13.0.tgz",
-      "integrity": "sha512-b/gGtdOcRSak8xfN93InDwPopBr3SXmJ4N2XJI8zw/BZRGX1as6R9JYMpwX6QZCoIm7t1ltvXSAKsfoAtzgxWA==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/eslint-config/-/eslint-config-1.14.0.tgz",
+      "integrity": "sha512-WRSbCVR8eeOhKYkW5s79VleXvn9/Le81MFirTEpOyYyMQgHi2J5R5cmHWcx5A+Wugs8yDpW1Xn+7g8RWKpuTgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@antfu/install-pkg": "^1.1.0",
-        "@clack/prompts": "^0.11.0",
+        "@clack/prompts": "^1.0.0",
         "@eslint/js": "^9.39.2",
-        "@nuxt/eslint-plugin": "1.13.0",
-        "@stylistic/eslint-plugin": "^5.7.0",
-        "@typescript-eslint/eslint-plugin": "^8.53.1",
-        "@typescript-eslint/parser": "^8.53.1",
+        "@nuxt/eslint-plugin": "1.14.0",
+        "@stylistic/eslint-plugin": "^5.7.1",
+        "@typescript-eslint/eslint-plugin": "^8.54.0",
+        "@typescript-eslint/parser": "^8.54.0",
         "eslint-config-flat-gitignore": "^2.1.0",
-        "eslint-flat-config-utils": "^3.0.0",
+        "eslint-flat-config-utils": "^3.0.1",
         "eslint-merge-processors": "^2.0.0",
         "eslint-plugin-import-lite": "^0.5.0",
         "eslint-plugin-import-x": "^4.16.1",
-        "eslint-plugin-jsdoc": "^62.3.1",
+        "eslint-plugin-jsdoc": "^62.5.3",
         "eslint-plugin-regexp": "^3.0.0",
         "eslint-plugin-unicorn": "^62.0.0",
         "eslint-plugin-vue": "^10.7.0",
         "eslint-processor-vue-blocks": "^2.0.0",
-        "globals": "^17.1.0",
+        "globals": "^17.3.0",
         "local-pkg": "^1.1.2",
         "pathe": "^2.0.3",
         "vue-eslint-parser": "^10.2.0"
@@ -2044,14 +2002,14 @@
       }
     },
     "node_modules/@nuxt/eslint-plugin": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/eslint-plugin/-/eslint-plugin-1.13.0.tgz",
-      "integrity": "sha512-QMMFxDNaTY0ur2wAVsGC8vGHVlSONV9qPclze0xG6tUX/4G/xrDbNkSYeRIbYf6/Nk4rYFiXxS0CDUJFwUKidg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/eslint-plugin/-/eslint-plugin-1.14.0.tgz",
+      "integrity": "sha512-NT53GrmGaCQVXzScKSPe8scflxOZeFLONmmwHYh8sUKlnNZyFoxsmnN/AiZcDKDZ+OUjWhBrirDgDIXTTdM6xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "^8.53.1",
-        "@typescript-eslint/utils": "^8.53.1"
+        "@typescript-eslint/types": "^8.54.0",
+        "@typescript-eslint/utils": "^8.54.0"
       },
       "peerDependencies": {
         "eslint": "^9.0.0"
@@ -2566,10 +2524,11 @@
       }
     },
     "node_modules/@nuxt/kit": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.3.0.tgz",
-      "integrity": "sha512-cD/0UU9RQmlnTbmyJTDyzN8f6CzpziDLv3tFQCnwl0Aoxt3KmFu4k/XA4Sogxqj7jJ/3cdX1kL+Lnsh34sxcQQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.3.1.tgz",
+      "integrity": "sha512-UjBFt72dnpc+83BV3OIbCT0YHLevJtgJCHpxMX0YRKWLDhhbcDdUse87GtsQBrjvOzK7WUNUYLDS/hQLYev5rA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "c12": "^3.3.3",
         "consola": "^3.4.2",
@@ -2584,9 +2543,9 @@
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.0",
-        "rc9": "^2.1.2",
+        "rc9": "^3.0.0",
         "scule": "^1.3.0",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "tinyglobby": "^0.2.15",
         "ufo": "^1.6.3",
         "unctx": "^2.5.0",
@@ -2597,14 +2556,14 @@
       }
     },
     "node_modules/@nuxt/nitro-server": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/nitro-server/-/nitro-server-4.3.0.tgz",
-      "integrity": "sha512-NkI8q8211BTLfQr6m24PjBp9GGyKWJMxRGSqe5WGgpQD5BpSnlvM8l1HaaP4xn9/P4v1Hp/LxX+vYElY2fw/zw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/nitro-server/-/nitro-server-4.3.1.tgz",
+      "integrity": "sha512-4aNiM69Re02gI1ywnDND0m6QdVKXhWzDdtvl/16veytdHZj3FSq57ZCwOClNJ7HQkEMqXgS+bi6S2HmJX+et+g==",
       "license": "MIT",
       "dependencies": {
         "@nuxt/devalue": "^2.0.2",
-        "@nuxt/kit": "4.3.0",
-        "@unhead/vue": "^2.1.2",
+        "@nuxt/kit": "4.3.1",
+        "@unhead/vue": "^2.1.3",
         "@vue/shared": "^3.5.27",
         "consola": "^3.4.2",
         "defu": "^6.1.4",
@@ -2634,7 +2593,7 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "nuxt": "^4.3.0"
+        "nuxt": "^4.3.1"
       }
     },
     "node_modules/@nuxt/nitro-server/node_modules/escape-string-regexp": {
@@ -2650,9 +2609,9 @@
       }
     },
     "node_modules/@nuxt/schema": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.3.0.tgz",
-      "integrity": "sha512-+Ps3exseMFH3MOapbBmDdpaHpPV7wqcB6+Ir9w8h91771HwMOWrQomAZpqDvw7FtFraoD5Xw7dhSKDhkwJRSmQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.3.1.tgz",
+      "integrity": "sha512-S+wHJdYDuyk9I43Ej27y5BeWMZgi7R/UVql3b3qtT35d0fbpXW7fUenzhLRCCDC6O10sjguc6fcMcR9sMKvV8g==",
       "license": "MIT",
       "dependencies": {
         "@vue/shared": "^3.5.27",
@@ -2666,74 +2625,38 @@
       }
     },
     "node_modules/@nuxt/telemetry": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/@nuxt/telemetry/-/telemetry-2.6.6.tgz",
-      "integrity": "sha512-Zh4HJLjzvm3Cq9w6sfzIFyH9ozK5ePYVfCUzzUQNiZojFsI2k1QkSBrVI9BGc6ArKXj/O6rkI6w7qQ+ouL8Cag==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/telemetry/-/telemetry-2.7.0.tgz",
+      "integrity": "sha512-mrKC3NjAlBOooLLVTYcIUie1meipoYq5vkoESoVTEWTB34T3a0QJzOfOPch+HYlUR+5Lqy1zLMv6epHFgYAKLA==",
       "license": "MIT",
       "dependencies": {
-        "@nuxt/kit": "^3.15.4",
-        "citty": "^0.1.6",
+        "citty": "^0.2.0",
         "consola": "^3.4.2",
-        "destr": "^2.0.3",
-        "dotenv": "^16.4.7",
-        "git-url-parse": "^16.0.1",
-        "is-docker": "^3.0.0",
-        "ofetch": "^1.4.1",
-        "package-manager-detector": "^1.1.0",
-        "pathe": "^2.0.3",
-        "rc9": "^2.1.2",
-        "std-env": "^3.8.1"
+        "ofetch": "^2.0.0-alpha.3",
+        "rc9": "^3.0.0",
+        "std-env": "^3.10.0"
       },
       "bin": {
         "nuxt-telemetry": "bin/nuxt-telemetry.mjs"
       },
       "engines": {
         "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "@nuxt/kit": ">=3.0.0"
       }
     },
-    "node_modules/@nuxt/telemetry/node_modules/@nuxt/kit": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.0.tgz",
-      "integrity": "sha512-KMTLK/dsGaQioZzkYUvgfN9le4grNW54aNcA1jqzgVZLcFVy4jJfrJr5WZio9NT2EMfajdoZ+V28aD7BRr4Zfw==",
-      "license": "MIT",
-      "dependencies": {
-        "c12": "^3.3.3",
-        "consola": "^3.4.2",
-        "defu": "^6.1.4",
-        "destr": "^2.0.5",
-        "errx": "^0.1.0",
-        "exsolve": "^1.0.8",
-        "ignore": "^7.0.5",
-        "jiti": "^2.6.1",
-        "klona": "^2.0.6",
-        "knitwork": "^1.3.0",
-        "mlly": "^1.8.0",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "rc9": "^2.1.2",
-        "scule": "^1.3.0",
-        "semver": "^7.7.3",
-        "tinyglobby": "^0.2.15",
-        "ufo": "^1.6.3",
-        "unctx": "^2.5.0",
-        "untyped": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      }
+    "node_modules/@nuxt/telemetry/node_modules/citty": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.0.tgz",
+      "integrity": "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==",
+      "license": "MIT"
     },
-    "node_modules/@nuxt/telemetry/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
+    "node_modules/@nuxt/telemetry/node_modules/ofetch": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==",
+      "license": "MIT"
     },
     "node_modules/@nuxt/test-utils": {
       "version": "3.23.0",
@@ -2842,9 +2765,9 @@
       }
     },
     "node_modules/@nuxt/test-utils/node_modules/@nuxt/kit": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.0.tgz",
-      "integrity": "sha512-KMTLK/dsGaQioZzkYUvgfN9le4grNW54aNcA1jqzgVZLcFVy4jJfrJr5WZio9NT2EMfajdoZ+V28aD7BRr4Zfw==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.1.tgz",
+      "integrity": "sha512-QORZRjcuTKgo++XP1Pc2c2gqwRydkaExrIRfRI9vFsPA3AzuHVn5Gfmbv1ic8y34e78mr5DMBvJlelUaeOuajg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2862,9 +2785,9 @@
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.0",
-        "rc9": "^2.1.2",
+        "rc9": "^3.0.0",
         "scule": "^1.3.0",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "tinyglobby": "^0.2.15",
         "ufo": "^1.6.3",
         "unctx": "^2.5.0",
@@ -2872,56 +2795,6 @@
       },
       "engines": {
         "node": ">=18.12.0"
-      }
-    },
-    "node_modules/@nuxt/test-utils/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/@nuxt/test-utils/node_modules/h3-next": {
-      "name": "h3",
-      "version": "2.0.1-rc.14",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.14.tgz",
-      "integrity": "sha512-163qbGmTr/9rqQRNuqMqtgXnOUAkE4KTdauiC9y0E5iG1I65kte9NyfWvZw5RTDMt6eY+DtyoNzrQ9wA2BfvGQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rou3": "^0.7.12",
-        "srvx": "^0.11.2"
-      },
-      "bin": {
-        "h3": "bin/h3.mjs"
-      },
-      "engines": {
-        "node": ">=20.11.1"
-      },
-      "peerDependencies": {
-        "crossws": "^0.4.1"
-      },
-      "peerDependenciesMeta": {
-        "crossws": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nuxt/test-utils/node_modules/srvx": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.2.tgz",
-      "integrity": "sha512-u6NbjE84IJwm1XUnJ53WqylLTQ3BdWRw03lcjBNNeMBD+EFjkl0Cnw1RVaGSqRAo38pOHOPXJH30M6cuTINUxw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "srvx": "bin/srvx.mjs"
-      },
-      "engines": {
-        "node": ">=20.16.0"
       }
     },
     "node_modules/@nuxt/ui": {
@@ -3042,20 +2915,20 @@
       }
     },
     "node_modules/@nuxt/vite-builder": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-4.3.0.tgz",
-      "integrity": "sha512-qOVevlukWUztfJ9p/OtujRxwaXIsnoTo2ZW4pPY1zQcuR1DtBtBsiePLzftoDz1VGx9JF5GAx9YyrgTn/EmcWQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-4.3.1.tgz",
+      "integrity": "sha512-LndnxPJzDUDbWAB8q5gZZN1mSOLHEyMOoj4T3pTdPydGf31QZdMR0V1fQ1fdRgtgNtWB3WLP0d1ZfaAOITsUpw==",
       "license": "MIT",
       "dependencies": {
-        "@nuxt/kit": "4.3.0",
+        "@nuxt/kit": "4.3.1",
         "@rollup/plugin-replace": "^6.0.3",
-        "@vitejs/plugin-vue": "^6.0.3",
-        "@vitejs/plugin-vue-jsx": "^5.1.3",
-        "autoprefixer": "^10.4.23",
+        "@vitejs/plugin-vue": "^6.0.4",
+        "@vitejs/plugin-vue-jsx": "^5.1.4",
+        "autoprefixer": "^10.4.24",
         "consola": "^3.4.2",
         "cssnano": "^7.1.2",
         "defu": "^6.1.4",
-        "esbuild": "^0.27.2",
+        "esbuild": "^0.27.3",
         "escape-string-regexp": "^5.0.0",
         "exsolve": "^1.0.8",
         "get-port-please": "^3.2.0",
@@ -3068,7 +2941,7 @@
         "pkg-types": "^2.3.0",
         "postcss": "^8.5.6",
         "rollup-plugin-visualizer": "^6.0.5",
-        "seroval": "^1.4.2",
+        "seroval": "^1.5.0",
         "std-env": "^3.10.0",
         "ufo": "^1.6.3",
         "unenv": "^2.0.0-rc.24",
@@ -3081,7 +2954,7 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "nuxt": "4.3.0",
+        "nuxt": "4.3.1",
         "rolldown": "^1.0.0-beta.38",
         "vue": "^3.3.4"
       },
@@ -3116,9 +2989,9 @@
       }
     },
     "node_modules/@nuxtjs/color-mode/node_modules/@nuxt/kit": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.0.tgz",
-      "integrity": "sha512-KMTLK/dsGaQioZzkYUvgfN9le4grNW54aNcA1jqzgVZLcFVy4jJfrJr5WZio9NT2EMfajdoZ+V28aD7BRr4Zfw==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.1.tgz",
+      "integrity": "sha512-QORZRjcuTKgo++XP1Pc2c2gqwRydkaExrIRfRI9vFsPA3AzuHVn5Gfmbv1ic8y34e78mr5DMBvJlelUaeOuajg==",
       "license": "MIT",
       "dependencies": {
         "c12": "^3.3.3",
@@ -3135,9 +3008,9 @@
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.0",
-        "rc9": "^2.1.2",
+        "rc9": "^3.0.0",
         "scule": "^1.3.0",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "tinyglobby": "^0.2.15",
         "ufo": "^1.6.3",
         "unctx": "^2.5.0",
@@ -3201,9 +3074,9 @@
       "license": "MIT"
     },
     "node_modules/@oxc-minify/binding-android-arm-eabi": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm-eabi/-/binding-android-arm-eabi-0.110.0.tgz",
-      "integrity": "sha512-43fMTO8/5bMlqfOiNSZNKUzIqeLIYuB9Hr1Ohyf58B1wU11S2dPGibTXOGNaWsfgHy99eeZ1bSgeIHy/fEYqbw==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm-eabi/-/binding-android-arm-eabi-0.112.0.tgz",
+      "integrity": "sha512-m7TGBR2hjsBJIN9UJ909KBoKsuogo6CuLsHKvUIBXdjI0JVHP8g4ZHeB+BJpGn5LJdeSGDfz9MWiuXrZDRzunw==",
       "cpu": [
         "arm"
       ],
@@ -3217,9 +3090,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-android-arm64": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.110.0.tgz",
-      "integrity": "sha512-5oQrnn9eK/ccOp80PTrNj0Vq893NPNNRryjGpOIVsYNgWFuoGCfpnKg68oEFcN8bArizYAqw4nvgHljEnar69w==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.112.0.tgz",
+      "integrity": "sha512-RvxOOkzvP5NeeoraBtgNJSBqO+XzlS7DooxST/drAXCfO52GsmxVB1N7QmifrsTYtH8GC2z3DTFjZQ1w/AJOWg==",
       "cpu": [
         "arm64"
       ],
@@ -3233,9 +3106,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-darwin-arm64": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.110.0.tgz",
-      "integrity": "sha512-dqBDgTG9tF2z2lrZp9E8wU+Godz1i8gCGSei2eFKS2hRploBOD5dmOLp1j4IMornkPvSQmbwB3uSjPq7fjx4EA==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.112.0.tgz",
+      "integrity": "sha512-hDslO3uVHza3kB9zkcsi25JzN65Gj5ZYty0OvylS11Mhg9ydCYxAzfQ/tISHW/YmV1NRUJX8+GGqM1cKmrHaTA==",
       "cpu": [
         "arm64"
       ],
@@ -3249,9 +3122,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-darwin-x64": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.110.0.tgz",
-      "integrity": "sha512-U0AqabqaooDOpYmeeOye8wClv8PSScELXgOfYqyqgrwH9J9KrpCE1jL8Rlqgz68QbL4mPw3V6sKiiHssI4CLeQ==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.112.0.tgz",
+      "integrity": "sha512-mWA2Y5bUyNoGM+gSGGHesgtQ3LDWgpRe4zDGkBDovxNIiDLBXqu/7QcuS+G918w8oG9VYm1q1iinILer/2pD1Q==",
       "cpu": [
         "x64"
       ],
@@ -3265,9 +3138,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-freebsd-x64": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.110.0.tgz",
-      "integrity": "sha512-H0w8o/Wo1072WSdLfhwwrpFpwZnPpjQODlHuRYkTfsSSSJbTxQtjJd4uxk7YJsRv5RQp69y0I7zvdH6f8Xueyw==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.112.0.tgz",
+      "integrity": "sha512-T7fsegxcy82xS0jWPXkz/BMhrkb3D7YOCiV0R9pDksjaov+iIFoNEWAoBsaC5NtpdzkX+bmffwDpu336EIfEeg==",
       "cpu": [
         "x64"
       ],
@@ -3281,9 +3154,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-arm-gnueabihf": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.110.0.tgz",
-      "integrity": "sha512-qd6sW0AvEVYZhbVVMGtmKZw3b1zDYGIW+54Uh42moWRAj6i4Jhk/LGr6r9YNZpOINeuvZfkFuEeDD/jbu7xPUA==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.112.0.tgz",
+      "integrity": "sha512-yePavbIilAcpVYc8vRsDCn3xJxHMXDZIiamyH9fuLosAHNELcLib4/JR4fhDk4NmHVagQH3kRhsnm5Q9cm3pAw==",
       "cpu": [
         "arm"
       ],
@@ -3297,9 +3170,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-arm-musleabihf": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.110.0.tgz",
-      "integrity": "sha512-7WXP0aXMrWSn0ScppUBi3jf68ebfBG0eri8kxLmBOVSBj6jw1repzkHMITJMBeLr5d0tT/51qFEptiAk2EP2iA==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.112.0.tgz",
+      "integrity": "sha512-lmPWLXtW6FspERhy97iP0hwbmLtL66xI29QQ9GpHmTiE4k+zv/FaefuV/Qw+LuHnmFSYzUNrLcxh4ulOZTIP2g==",
       "cpu": [
         "arm"
       ],
@@ -3313,9 +3186,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-arm64-gnu": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.110.0.tgz",
-      "integrity": "sha512-LYfADrq5x1W5gs+u9OIbMbDQNYkAECTXX0ufnAuf3oGmO51rF98kGFR5qJqC/6/csokDyT3wwTpxhE0TkcF/Og==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.112.0.tgz",
+      "integrity": "sha512-gySS5XqU5MKs/oCjsTlVm8zb8lqcNKHEANsaRmhW2qvGKJoeGwFb6Fbq6TLCZMRuk143mLbncbverBCa1c3dog==",
       "cpu": [
         "arm64"
       ],
@@ -3329,9 +3202,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-arm64-musl": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.110.0.tgz",
-      "integrity": "sha512-53GjCVY8kvymk9P6qNDh6zyblcehF5QHstq9QgCjv13ONGRnSHjeds0PxIwiihD7h295bxsWs84DN39syLPH4Q==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.112.0.tgz",
+      "integrity": "sha512-IRFMZX589lr3rjG0jc8N261/7wqFq2Vl0OMrJWeFls5BF8HiB+fRYuf0Zy2CyRH6NCY2vbdDdp+QCAavQGVsGw==",
       "cpu": [
         "arm64"
       ],
@@ -3345,9 +3218,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-ppc64-gnu": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.110.0.tgz",
-      "integrity": "sha512-li8XcN81dxbJDMBESnTgGhoiAQ+CNIdM0QGscZ4duVPjCry1RpX+5FJySFbGqG3pk4s9ZzlL/vtQtbRzZIZOzg==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.112.0.tgz",
+      "integrity": "sha512-V/69XqIW9hCUceDpcZh79oDg+F4ptEgIfKRENzYs41LRbSoJ7sNjjcW4zifqyviTvzcnXLgK4uoTyoymmNZBMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -3361,9 +3234,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-riscv64-gnu": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.110.0.tgz",
-      "integrity": "sha512-SweKfsnLKShu6UFV8mwuj1d1wmlNoL/FlAxPUzwjEBgwiT2HQkY24KnjBH+TIA+//1O83kzmWKvvs4OuEhdIEQ==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.112.0.tgz",
+      "integrity": "sha512-zghvexySyGXGNW+MutjZN7UGTyOQl56RWMlPe1gb+knBm/+0hf9qjk7Q6ofm2tSte+vQolPfQttifGl0dP9uvQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3377,9 +3250,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-riscv64-musl": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.110.0.tgz",
-      "integrity": "sha512-oH8G4aFMP8XyTsEpdANC5PQyHgSeGlopHZuW1rpyYcaErg5YaK0vXjQ4EM5HVvPm+feBV24JjxgakTnZoF3aOQ==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.112.0.tgz",
+      "integrity": "sha512-E4a8VUFDJPb2mPcc7J4NQQPi1ssHKF7/g4r6KD2+SBVERIaEEd3cGNqR7SG3g82/BLGV2UDoQe/WvZCkt5M/bQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3393,9 +3266,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-s390x-gnu": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.110.0.tgz",
-      "integrity": "sha512-W9na+Vza7XVUlpf8wMt4QBfH35KeTENEmnpPUq3NSlbQHz8lSlSvhAafvo43NcKvHAXV3ckD/mUf2VkqSdbklg==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.112.0.tgz",
+      "integrity": "sha512-2Hx87sK3y6jBV364Mvv0zyxiITIuy26Ixenv6pK7e+4an3HgNdhAj8nk3aLoLTTSvLik5/MaGhcZGEu9tYV1aA==",
       "cpu": [
         "s390x"
       ],
@@ -3409,9 +3282,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-x64-gnu": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.110.0.tgz",
-      "integrity": "sha512-XJdA4mmmXOjJxSRgNJXsDP7Xe8h3gQhmb56hUcCrvq5d+h5UcEi2pR8rxsdIrS8QmkLuBA3eHkGK8E27D7DTgQ==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.112.0.tgz",
+      "integrity": "sha512-2MSCnEPLk9ddSouMhJo78Xy2/JbYC80OYzWdR4yWTGSULsgH3d1VXg73DSwFL8vU7Ad9oK10DioBY2ww7sQTEg==",
       "cpu": [
         "x64"
       ],
@@ -3425,9 +3298,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-x64-musl": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.110.0.tgz",
-      "integrity": "sha512-QqzvALuOTtSckI8x467R4GNArzYDb/yEh6aNzLoeaY1O7vfT7SPDwlOEcchaTznutpeS9Dy8gUS/AfqtUHaufw==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.112.0.tgz",
+      "integrity": "sha512-HAPfmQKlkVi97/zRonVE9t/kKUG3ni+mOuU1Euw+3s37KwUuOJjmcwXdclVgXKBlTkCGO0FajPwW5dAJeIXCCw==",
       "cpu": [
         "x64"
       ],
@@ -3441,9 +3314,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-openharmony-arm64": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-openharmony-arm64/-/binding-openharmony-arm64-0.110.0.tgz",
-      "integrity": "sha512-gAMssLs2Q3+uhLZxanh1DF+27Kaug3cf4PXb9AB7XK81DR+LVcKySXaoGYoOs20Co0fFSphd6rRzKge2qDK3dA==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-openharmony-arm64/-/binding-openharmony-arm64-0.112.0.tgz",
+      "integrity": "sha512-bLnMojcPadYzMNpB6IAqMiTOag4etc0zbs8On73JsotO1W5c5/j/ncplpSokpEpNasKRUpHVRXpmq0KRXprNhw==",
       "cpu": [
         "arm64"
       ],
@@ -3457,9 +3330,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-wasm32-wasi": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.110.0.tgz",
-      "integrity": "sha512-7Wqi5Zjl022bs2zXq+ICdalDPeDuCH/Nhbi8q2isLihAonMVIT0YH2hqqnNEylRNGYck+FJ6gRZwMpGCgrNxPg==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.112.0.tgz",
+      "integrity": "sha512-tv7PmHYq/8QBlqMaDjsy51GF5KQkG17Yc/PsgB5OVndU34kwbQuebBIic7UfK9ygzidI8moYq3ztnu3za/rqHw==",
       "cpu": [
         "wasm32"
       ],
@@ -3473,9 +3346,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-win32-arm64-msvc": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.110.0.tgz",
-      "integrity": "sha512-ZPx+0Tj4dqn41ecyoGotlvekQKy6JxJCixn9Rw7h/dafZ3eDuBcEVh3c2ZoldXXsyMIt5ywI8IWzFZsjNedd5Q==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.112.0.tgz",
+      "integrity": "sha512-d+jes2jwRkcBSpcaZC6cL8GBi56Br6uAorn9dfquhWLczWL+hHSvvVrRgT1i5/6dkf5UWx2zdoEsAMiJ11w78A==",
       "cpu": [
         "arm64"
       ],
@@ -3489,9 +3362,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-win32-ia32-msvc": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.110.0.tgz",
-      "integrity": "sha512-H0Oyd3RWBfpEyvJIrFK94RYiY7KKSQl11Ym7LMDwLEagelIAfRCkt1amHZhFa/S3ZRoaOJFXzEw4YKeSsjVFsg==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.112.0.tgz",
+      "integrity": "sha512-TV1C3qDwj7//jNIi5tnNRhReSUgtaRQKi5KobDE6zVAc5gjeuBA8G2qizS9ziXlf/I0dlelrGmGMMDJmH9ekWg==",
       "cpu": [
         "ia32"
       ],
@@ -3505,9 +3378,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-win32-x64-msvc": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.110.0.tgz",
-      "integrity": "sha512-Hr3nK90+qXKJ2kepXwFIcNfQQIOBecB4FFCyaMMypthoEEhVP08heRynj4eSXZ8NL9hLjs3fQzH8PJXfpznRnQ==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.112.0.tgz",
+      "integrity": "sha512-LML2Gld6VY8/+7a3VH4k1qngsBXvTkXgbmYgSYwaElqtiQiYaAcXfi0XKOUGe3k3GbBK4juAGixC31CrdFHAQw==",
       "cpu": [
         "x64"
       ],
@@ -3521,9 +3394,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.110.0.tgz",
-      "integrity": "sha512-g6+kHTI/BRDJszaZkSgyu0pGuMIVYJ7/v0I4C9BkTeGn1LxF9GWI6jE22dBEELXMWbG7FTyNlD9RCuWlStAx6w==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.112.0.tgz",
+      "integrity": "sha512-retxBzJ39Da7Lh/eZTn9+HJgTeDUxZIpuI0urOsmcFsBKXAth3lc1jIvwseQ9qbAI/VrsoFOXiGIzgclARbAHg==",
       "cpu": [
         "arm"
       ],
@@ -3537,9 +3410,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-android-arm64": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.110.0.tgz",
-      "integrity": "sha512-tbr+uWFVUN6p9LYlR0cPyFA24HWlnRYU+oldWlEGis/tdMtya3BubQcKdylhFhhDLaW6ChCJfxogQranElGVsw==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.112.0.tgz",
+      "integrity": "sha512-pRkbBRbuIIsufUWpOJ+JHWfJFNupkidy4sbjfcm37e6xwYrn9LSKMLubPHvNaL1Zf92ZRhGiwaYkEcmaFg2VcA==",
       "cpu": [
         "arm64"
       ],
@@ -3553,9 +3426,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.110.0.tgz",
-      "integrity": "sha512-jPBsXPc8hwmsUQyLMg7a5Ll/j/8rWCDFoB8WzLP6C0qQKX0zWQxbfSdLFg9GGNPuRo8J8ma9WfBQN5RmbFxNJA==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.112.0.tgz",
+      "integrity": "sha512-fh6/KQL/cbH5DukT3VkdCqnULLuvVnszVKySD5IgSE0WZb32YZo/cPsPdEv052kk6w3N4agu+NTiMnZjcvhUIg==",
       "cpu": [
         "arm64"
       ],
@@ -3569,9 +3442,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.110.0.tgz",
-      "integrity": "sha512-jt5G1eZj4sdMGc7Q0c6kfPRmqY1Mn3yzo6xuRr8EXozkh93O8KGFflABY7t56WIrmP+cloaCQkLcjlm6vdhzcQ==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.112.0.tgz",
+      "integrity": "sha512-vUBOOY1E30vlu/DoTGDoT1UbLlwu5Yv9tqeBabAwRzwNDz8Skho16VKhsBDUiyqddtpsR3//v6vNk38w4c+6IA==",
       "cpu": [
         "x64"
       ],
@@ -3585,9 +3458,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.110.0.tgz",
-      "integrity": "sha512-VJ7Hwf4dg7uf8b/DrLEhE6lgnNTfBZbTqXQBG3n0oCBoreE1c5aWf1la+o7fJjjTpACRts/vAZ2ngFNNqEFpJw==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.112.0.tgz",
+      "integrity": "sha512-hnEtO/9AVnYWzrgnp6L+oPs/6UqlFeteUL6n7magkd2tttgmx1C01hyNNh6nTpZfLzEVJSNJ0S+4NTsK2q2CxA==",
       "cpu": [
         "x64"
       ],
@@ -3601,9 +3474,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.110.0.tgz",
-      "integrity": "sha512-w3OZ0pLKktM7k4qEbVj3dHnCvSMFnWugYxHfhpwncYUOxwDNL3mw++EOIrw997QYiEuJ+H6Od8K6mbj1p6Ae8w==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.112.0.tgz",
+      "integrity": "sha512-WxJrUz3pcIc2hp4lvJbvt/sTL33oX9NPvkD3vDDybE6tc0V++rS+hNOJxwXdD2FDIFPkHs/IEn5asEZFVH+VKw==",
       "cpu": [
         "arm"
       ],
@@ -3617,9 +3490,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.110.0.tgz",
-      "integrity": "sha512-BIaoW4W6QKb8Q6p3DErDtsAuDRAnr0W+gtwo7fQQkbAJpoPII0ZJXZn+tcQGCyNGKWSsilRNWHyd/XZfXXXpzw==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.112.0.tgz",
+      "integrity": "sha512-jj8A8WWySaJQqM9XKAIG8U2Q3qxhFQKrXPWv98d1oC35at+L1h+C+V4M3l8BAKhpHKCu3dYlloaAbHd5q1Hw6A==",
       "cpu": [
         "arm"
       ],
@@ -3633,9 +3506,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.110.0.tgz",
-      "integrity": "sha512-3EQDJze28t0HdxXjMKBU6utNscXJePg2YV0Kd/ZnHx24VcIyfkNH6NKzBh0NeaWHovDTkpzYHPtF2tOevtbbfw==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.112.0.tgz",
+      "integrity": "sha512-G2F8H6FcAExVK5vvhpSh61tqWx5QoaXXUnSsj5FyuDiFT/K7AMMVSQVqnZREDc+YxhrjB0vnKjCcuobXK63kIw==",
       "cpu": [
         "arm64"
       ],
@@ -3649,9 +3522,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.110.0.tgz",
-      "integrity": "sha512-5xwm1hPrGGvjCVtTWNGJ39MmQGnyipoIDShneGBgSrnDh0XX+COAO7AZKajgNipqgNq5rGEItpzFkMtSDyx0bQ==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.112.0.tgz",
+      "integrity": "sha512-3R0iqjM3xYOZCnwgcxOQXH7hrz64/USDIuLbNTM1kZqQzRqaR4w7SwoWKU934zABo8d0op2oSwOp+CV3hZnM7A==",
       "cpu": [
         "arm64"
       ],
@@ -3665,9 +3538,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.110.0.tgz",
-      "integrity": "sha512-I8Xop7z+enuvW1xe0AcRQ9XqFNkUYgeXusyGjCyW6TstRb62P90h+nL1AoGaUMy0E0518DJam5vRYVRgXaAzYg==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.112.0.tgz",
+      "integrity": "sha512-lAQf8PQxfgy7h0bmcfSVE3hg3qMueshPYULFsCrHM+8KefGZ9W+ZMvRyU33gLrB4w1O3Fz1orR0hmKMCRxXNrQ==",
       "cpu": [
         "ppc64"
       ],
@@ -3681,9 +3554,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.110.0.tgz",
-      "integrity": "sha512-XPM0jpght/AuHnweNaIo0twpId6rWFs8NrTkMijxcsRQMzNBeSQQgYm9ErrutmKQS6gb8XNAEIkYXHgPmhdDPg==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.112.0.tgz",
+      "integrity": "sha512-2QlvQBUhHuAE3ezD4X3CAEKMXdfgInggQ5Bj/7gb5NcYP3GyfLTj7c+mMu+BRwfC9B3AXBNyqHWbqEuuUvZyRQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3697,9 +3570,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.110.0.tgz",
-      "integrity": "sha512-ylJIuJyMzAqR191QeCwZLEkyo4Sx817TNILjNhT0W1EDQusGicOYKSsGXM/2DHCNYGcidV+MQ8pUVzNeVmuM6g==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.112.0.tgz",
+      "integrity": "sha512-v06iu0osHszgqJ1dLQRb6leWFU1sjG/UQk4MoVBtE6ZPewgfTkby6G9II1SpEAf2onnAuQceVYxQH9iuU3NJqw==",
       "cpu": [
         "riscv64"
       ],
@@ -3713,9 +3586,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.110.0.tgz",
-      "integrity": "sha512-DL6oR0PfYor9tBX9xlAxMUVwfm6+sKTL4H+KiQ6JKP3xkJTwBIdDCgeN2AjMht1D3N40uUwVq3v8/2fqnZRgLQ==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.112.0.tgz",
+      "integrity": "sha512-+5HhNHtxsdcd7+ljXFnn9FOoCNXJX3UPgIfIE6vdwS1HqdGNH6eAcVobuqGOp54l8pvcxDQA6F4cPswCgLrQfQ==",
       "cpu": [
         "s390x"
       ],
@@ -3729,9 +3602,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.110.0.tgz",
-      "integrity": "sha512-+e6ws5JLpFehdK+wh6q8icx1iM3Ao+9dtItVWFcRiXxSvGcIlS9viWcMvXKrmcsyVDUf81dnvuMSBigNslxhIQ==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.112.0.tgz",
+      "integrity": "sha512-jKwO7ZLNkjxwg7FoCLw+fJszooL9yXRZsDN0AQ1AQUTWq1l8GH/2e44k68N3fcP19jl8O8jGpqLAZcQTYk6skA==",
       "cpu": [
         "x64"
       ],
@@ -3745,9 +3618,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.110.0.tgz",
-      "integrity": "sha512-6DiYhVdXKOzB01+j/tyrB6/d2o6b4XYFQvcbBRNbVHIimS6nl992y3V3mGG3NaA+uCZAzhT3M3btTdKAxE4A3A==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.112.0.tgz",
+      "integrity": "sha512-TYqnuKV/p3eOc+N61E0961nA7DC+gaCeJ3+V2LcjJdTwFMdikqWL6uVk1jlrpUCBrozHDATVUKDZYH7r4FQYjQ==",
       "cpu": [
         "x64"
       ],
@@ -3761,9 +3634,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-openharmony-arm64": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.110.0.tgz",
-      "integrity": "sha512-U9KEK7tXdHrXl2eZpoHYGWj31ZSvdGiaXwjkJzeRN0elt89PXi+VcryRh6BAFbEz1EQpTteyMDwDXMgJVWM85A==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.112.0.tgz",
+      "integrity": "sha512-ZhrVmWFifVEFQX4XPwLoVFDHw9tAWH9p9vHsHFH+5uCKdfVR+jje4WxVo6YrokWCboGckoOzHq5KKMOcPZfkRg==",
       "cpu": [
         "arm64"
       ],
@@ -3777,9 +3650,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-wasm32-wasi": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.110.0.tgz",
-      "integrity": "sha512-cK2j/GbXGxP7k4qDM0OGjkbPrIOj8n9+U/27joH/M19z+jrQ5u1lvlvbAK/Aw2LnqE0waADnnuAc0MFab+Ea8w==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.112.0.tgz",
+      "integrity": "sha512-Gr8X2PUU3hX1g3F5oLWIZB8DhzDmjr5TfOrmn5tlBOo9l8ojPGdKjnIBfObM7X15928vza8QRKW25RTR7jfivg==",
       "cpu": [
         "wasm32"
       ],
@@ -3793,9 +3666,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.110.0.tgz",
-      "integrity": "sha512-ZW393ysGT5oZeGJRyw2JAz4tIfyTjVCSxuZoh8e+7J7e0QPDH/SAmyxJXb/aMxarIVa3OcYZ5p/Q6eooHZ0i1Q==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.112.0.tgz",
+      "integrity": "sha512-t5CDLbU70Ea88bGRhvU/dLJTc/Wcrtf2Jp534E8P3cgjAvHDjdKsfDDqBZrhybJ8Jv9v9vW5ngE40EK51BluDA==",
       "cpu": [
         "arm64"
       ],
@@ -3809,9 +3682,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.110.0.tgz",
-      "integrity": "sha512-NM50LT1PEnlMlw+z/TFVkWaDOF/s5DRHbU3XhEESNhDDT9qYA8N9B1V/FYxVr1ngu28JGK2HtkjpWKlKoF4E2Q==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.112.0.tgz",
+      "integrity": "sha512-rZH0JynCCwnhe2HfRoyNOl/Kfd9pudoWxgpC5OZhj7j77pMK0UOAa35hYDfrtSOUk2HLzrikV5dPUOY2DpSBSA==",
       "cpu": [
         "ia32"
       ],
@@ -3825,9 +3698,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.110.0.tgz",
-      "integrity": "sha512-w1SzoXNaY59tbTz8/YhImByuj7kXP5EfPtv4+PPwPrvLrOWt8BOpK0wN8ysXqyWCdHv9vS1UBRrNd/aSp4Dy8A==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.112.0.tgz",
+      "integrity": "sha512-oGHluohzmVFAuQrkEnl1OXAxMz2aYmimxUqIgKXpBgbr7PvFv0doELB273sX+5V3fKeggohKg1A2Qq21W9Z9cQ==",
       "cpu": [
         "x64"
       ],
@@ -3841,18 +3714,18 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.110.0.tgz",
-      "integrity": "sha512-6Ct21OIlrEnFEJk5LT4e63pk3btsI6/TusD/GStLi7wYlGJNOl1GI9qvXAnRAxQU9zqA2Oz+UwhfTOU2rPZVow==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.112.0.tgz",
+      "integrity": "sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@oxc-transform/binding-android-arm-eabi": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm-eabi/-/binding-android-arm-eabi-0.110.0.tgz",
-      "integrity": "sha512-sE9dxvqqAax1YYJ3t7j+h5ZSI9jl6dYuDfngl6ieZUrIy5P89/8JKVgAzgp8o3wQSo7ndpJvYsi1K4ZqrmbP7w==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm-eabi/-/binding-android-arm-eabi-0.112.0.tgz",
+      "integrity": "sha512-r4LuBaPnOAi0eUOBNi880Fm2tO2omH7N1FRrL6+nyz/AjQ+QPPLtoyZJva0O+sKi1buyN/7IzM5p9m+5ANSDbg==",
       "cpu": [
         "arm"
       ],
@@ -3866,9 +3739,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-android-arm64": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.110.0.tgz",
-      "integrity": "sha512-nqtbP4aMCtsCZ6qpHlHaQoWVHSBtlKzwaAgwEOvR+9DWqHjk31BHvpGiDXlMeed6CVNpl3lCbWgygb3RcSjcfw==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.112.0.tgz",
+      "integrity": "sha512-ve46vQcQrY8eGe8990VSlS9gkD+AogJqbtfOkeua+5sQGQTDgeIRRxOm7ktCo19uZc2bEBwXRJITgosd+NRVmQ==",
       "cpu": [
         "arm64"
       ],
@@ -3882,9 +3755,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-darwin-arm64": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.110.0.tgz",
-      "integrity": "sha512-oeSeHnL4Z4cMXtc8V0/rwoVn0dgwlS9q0j6LcHn9dIhtFEdp3W0iSBF8YmMQA+E7sILeLDjsHmHE4Kp0sOScXw==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.112.0.tgz",
+      "integrity": "sha512-ddbmLU3Tr+i7MOynfwAXxUXud3SjJKlv7XNjaq08qiI8Av/QvhXVGc2bMhXkWQSMSBUeTDoiughKjK+Zsb6y/A==",
       "cpu": [
         "arm64"
       ],
@@ -3898,9 +3771,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-darwin-x64": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.110.0.tgz",
-      "integrity": "sha512-nL9K5x7OuZydobAGPylsEW9d4APs2qEkIBLMgQPA+kY8dtVD3IR87QsTbs4l4DBQYyun/+ay6qVCDlxqxdX2Jg==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.112.0.tgz",
+      "integrity": "sha512-TKvmNw96jQZPqYb4pRrzLFDailNB3YS14KNn+x2hwRbqc6CqY96S9PYwyOpVpYdxfoRjYO9WgX9SoS+62a1DPA==",
       "cpu": [
         "x64"
       ],
@@ -3914,9 +3787,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-freebsd-x64": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.110.0.tgz",
-      "integrity": "sha512-GS29zXXirDQhZEUq8xKJ1azAWMuUy3Ih3W5Bc5ddk12LRthO5wRLFcKIyeHpAXCoXymQ+LmxbMtbPf84GPxouw==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.112.0.tgz",
+      "integrity": "sha512-YPMkSCDaelO8HHYRMYjm+Q+IfkfIbdtQzwPuasItYkq8UUkNeHNPheNh2JkvQa3c+io3E9ePOgHQ2yihpk7o/Q==",
       "cpu": [
         "x64"
       ],
@@ -3930,9 +3803,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-arm-gnueabihf": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.110.0.tgz",
-      "integrity": "sha512-glzDHak8ISyZJemCUi7RCvzNSl+MQ1ly9RceT2qRufhUsvNZ4C/2QLJ1HJwd2N6E88bO4laYn+RofdRzNnGGEA==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.112.0.tgz",
+      "integrity": "sha512-nA7kzQGNEpuTRknst/IJ3l8hqmDmEda3aun6jkXgp7gKxESjuHeaNH04mKISxvJ7fIacvP2g/wtTSnm4u5jL8Q==",
       "cpu": [
         "arm"
       ],
@@ -3946,9 +3819,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-arm-musleabihf": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.110.0.tgz",
-      "integrity": "sha512-8JThvgJ2FRoTVfbp7e4wqeZqCZbtudM06SfZmNzND9kPNu/LVYygIR+72RWs+xm4bWkuYHg/islo/boNPtMT5Q==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.112.0.tgz",
+      "integrity": "sha512-w8GuLmckKlGc3YujaZKhtbFxziCcosvM2l9GnQjCb/yENWLGDiyQOy0BTAgPGdJwpYTiOeJblEXSuXYvlE1Ong==",
       "cpu": [
         "arm"
       ],
@@ -3962,9 +3835,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-arm64-gnu": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.110.0.tgz",
-      "integrity": "sha512-IRh21Ub/g4bkHoErZ0AUWMlWfoZaS0A6EaOVtbcY70RSYIMlrsbjiFwJCzM+b/1DD1rXbH5tsGcH7GweTbfRqg==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.112.0.tgz",
+      "integrity": "sha512-9LwwGnJ8+WT0rXcrI8M0RJtDNt91eMqcDPPEvJxhRFHIMcHTy5D5xT+fOl3Us0yMqKo3HUWkbfUYqAp4GoZ3Jw==",
       "cpu": [
         "arm64"
       ],
@@ -3978,9 +3851,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-arm64-musl": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.110.0.tgz",
-      "integrity": "sha512-e5JN94/oy+wevk76q+LMr+2klTTcO60uXa+Wkq558Ms7mdF2TvkKFI++d/JeiuIwJLTi/BxQ4qdT5FWcsHM/ug==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.112.0.tgz",
+      "integrity": "sha512-Lg6VOuSd3oXv7J0eGywgqh/086h+qQzIBOD+47pYKMTTJcbDe+f3h/RgGoMKJE5HhiwT5sH1aGEJfIfaYUiVSw==",
       "cpu": [
         "arm64"
       ],
@@ -3994,9 +3867,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-ppc64-gnu": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.110.0.tgz",
-      "integrity": "sha512-Y3/Tnnz1GvDpmv8FXBIKtdZPsdZklOEPdrL6NHrN5i2u54BOkybFaDSptgWF53wOrJlTrcmAVSE6fRKK9XCM2Q==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.112.0.tgz",
+      "integrity": "sha512-PXzmj82o1moA4IGphYImTRgc2youTi4VRfyFX3CHwLjxPcQ5JtcsgbDt4QUdOzXZ+zC07s5jf2ZzhRapEOlj2w==",
       "cpu": [
         "ppc64"
       ],
@@ -4010,9 +3883,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-riscv64-gnu": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.110.0.tgz",
-      "integrity": "sha512-Y0E35iA9/v9jlkNcP6tMJ+ZFOS0rLsWDqG6rU9z+X2R3fBFJBO9UARIK6ngx8upxk81y1TFR2CmBFhupfYdH6Q==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.112.0.tgz",
+      "integrity": "sha512-vhJsMsVH/6xwa3bt1LGts33FXUkGjaEGDwsRyp4lIfOjSfQVWMtCmWMFNaA0dW9FVWdD2Gt2fSFBSZ+azDxlpg==",
       "cpu": [
         "riscv64"
       ],
@@ -4026,9 +3899,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-riscv64-musl": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.110.0.tgz",
-      "integrity": "sha512-JOUSYFfHjBUs7xp2FHmZHb8eTYD/oEu0NklS6JgUauqnoXZHiTLPLVW2o2uVCqldnabYHcomuwI2iqVFYJNhTw==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.112.0.tgz",
+      "integrity": "sha512-cXWFb7z+2IjFUEcXtRwluq9oEG5qnyFCjiu3SWrgYNcWwPdHusv3I/7K5/CTbbi4StoZ5txbi7/iSfDHNyWuRw==",
       "cpu": [
         "riscv64"
       ],
@@ -4042,9 +3915,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-s390x-gnu": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.110.0.tgz",
-      "integrity": "sha512-7blgoXF9D3Ngzb7eun23pNrHJpoV/TtE6LObwlZ3Nmb4oZ6Z+yMvBVaoW68NarbmvNGfZ95zrOjgm6cVETLYBA==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.112.0.tgz",
+      "integrity": "sha512-eEFu4SRqJTJ20/88KRWmp+jpHKAw0Y1DsnSgpEeXyBIIcsOaLIUMU/TfYWUmqRbvbMV9rmOmI3kp5xWYUq6kSQ==",
       "cpu": [
         "s390x"
       ],
@@ -4058,9 +3931,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-x64-gnu": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.110.0.tgz",
-      "integrity": "sha512-YQ2joGWCVDZVEU2cD/r/w49hVjDm/Qu1BvC/7zs8LvprzdLS/HyMXGF2oA0puw0b+AqgYaz3bhwKB2xexHyITQ==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.112.0.tgz",
+      "integrity": "sha512-ST1MDT+TlOyZ1c5btrGinRSUW2Jf4Pa+0gdKwsyjDSOC3dxy2ZNkN3mosTf4ywc3J+mxfYKqtjs7zSwHz03ILA==",
       "cpu": [
         "x64"
       ],
@@ -4074,9 +3947,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-x64-musl": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.110.0.tgz",
-      "integrity": "sha512-fkjr5qE632ULmNgvFXWDR/8668WxERz3tU7TQFp6JebPBneColitjSkdx6VKNVXEoMmQnOvBIGeP5tUNT384oA==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.112.0.tgz",
+      "integrity": "sha512-ISQoA3pD4cyTGpf9sXXeerH6pL2L6EIpdy6oAy2ttkswyVFDyQNVOVIGIdLZDgbpmqGljxZnWqt/J/N68pQaig==",
       "cpu": [
         "x64"
       ],
@@ -4090,9 +3963,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-openharmony-arm64": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-openharmony-arm64/-/binding-openharmony-arm64-0.110.0.tgz",
-      "integrity": "sha512-HWH9Zj+lMrdSTqFRCZsvDWMz7OnMjbdGsm3xURXWfRZpuaz0bVvyuZNDQXc4FyyhRDsemICaJbU1bgeIpUJDGw==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-openharmony-arm64/-/binding-openharmony-arm64-0.112.0.tgz",
+      "integrity": "sha512-UOGVrGIv7yLJovyEXEyUTADuLq98vd/cbMHFLJweRXD+11I8Tn4jASi4WzdsN8C3BVYGRHrXH2NlSBmhz33a4g==",
       "cpu": [
         "arm64"
       ],
@@ -4106,9 +3979,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-wasm32-wasi": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-wasm32-wasi/-/binding-wasm32-wasi-0.110.0.tgz",
-      "integrity": "sha512-ejdxHmYfIcHDPhZUe3WklViLt9mDEJE5BzcW7+R1vc5i/5JFA8D0l7NUSsHBJ7FB8Bu9gF+5iMDm6cXGAgaghw==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-wasm32-wasi/-/binding-wasm32-wasi-0.112.0.tgz",
+      "integrity": "sha512-XIX7Gpq9koAvzBVHDlVFHM79r5uOVK6kTEsdsN4qaajpjkgtv4tdsAOKIYK6l7fUbsbE6xS+6w1+yRFrDeC1kg==",
       "cpu": [
         "wasm32"
       ],
@@ -4122,9 +3995,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-win32-arm64-msvc": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.110.0.tgz",
-      "integrity": "sha512-9VTwpXCZs7xkV+mKhQ62dVk7KLnLXtEUxNS2T4nLz3iMl1IJbA4h5oltK0JoobtiUAnbkV53QmMVGW8+Nh3bDQ==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.112.0.tgz",
+      "integrity": "sha512-EgXef9kOne9BNsbYBbuRqxk2hteT0xsAGcx/VbtCBMJYNj8fANFhT271DUSOgfa4DAgrQQmsyt/Kr1aV9mpU9w==",
       "cpu": [
         "arm64"
       ],
@@ -4138,9 +4011,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-win32-ia32-msvc": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.110.0.tgz",
-      "integrity": "sha512-5y0fzuNON7/F2hh2P94vANFaRPJ/3DI1hVl5rseCT8VUVqOGIjWaza0YS/D1g6t1WwycW2LWDMi2raOKoWU5GQ==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.112.0.tgz",
+      "integrity": "sha512-6QaB0qjNaou2YR+blncHdw7j0e26IOwOIjLbhVGDeuf9+4rjJeiqRXJ2hOtCcS4zblnao/MjdgQuZ3fM0nl+Kw==",
       "cpu": [
         "ia32"
       ],
@@ -4154,9 +4027,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-win32-x64-msvc": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.110.0.tgz",
-      "integrity": "sha512-QROrowwlrApI1fEScMknGWKM6GTM/Z2xwMnDqvSaEmzNazBsDUlE08Jasw610hFEsYAVU2K5sp/YaCa9ORdP4A==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.112.0.tgz",
+      "integrity": "sha512-FRKYlY959QeqRPx9kXs0HjU2xuXPT1cdF+vvA200D9uAX/KLcC34MwRqUKTYml4kCc2Vf/P2pBR9cQuBm3zECQ==",
       "cpu": [
         "x64"
       ],
@@ -4608,6 +4481,12 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-commonjs/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/plugin-inject": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
@@ -4629,6 +4508,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@rollup/plugin-inject/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
     },
     "node_modules/@rollup/plugin-json": {
       "version": "6.1.0",
@@ -4738,6 +4623,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
@@ -6130,21 +6021,15 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.2.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.1.tgz",
-      "integrity": "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==",
+      "version": "25.2.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.2.tgz",
+      "integrity": "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
-    },
-    "node_modules/@types/parse-path": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/parse-path/-/parse-path-7.0.3.tgz",
-      "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
-      "license": "MIT"
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -6397,13 +6282,13 @@
       }
     },
     "node_modules/@unhead/vue": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.3.tgz",
-      "integrity": "sha512-Cx0SvCPPOowHteJTpsI+sAQovYnmOgMdueL/McLIYyzJcSM1RBiB+4GJSWOvPDNBSK80SkyI654iWoW5V4UTTw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.4.tgz",
+      "integrity": "sha512-MFvywgkHMt/AqbhmKOqRuzvuHBTcmmmnUa7Wm/Sg11leXAeRShv2PcmY7IiYdeeJqBMCm1jwhcs6201jj6ggZg==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^6.0.1",
-        "unhead": "2.1.3"
+        "unhead": "2.1.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/harlan-zw"
@@ -6726,6 +6611,69 @@
         "node": ">=20"
       }
     },
+    "node_modules/@vercel/nft/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@vercel/nft/node_modules/glob": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.1.tgz",
+      "integrity": "sha512-B7U/vJpE3DkJ5WXTgTpTRN63uV42DseiXXKMwG14LQBXmsdeIoHAPbU/MEo6II0k5ED74uc2ZGTC6MwHFQhF6w==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.1.2",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/minimatch": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/path-scurry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@vercel/nft/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -6813,16 +6761,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@vitest/mocker/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/@vitest/pretty-format": {
@@ -7029,6 +6967,12 @@
         "source-map-js": "^1.2.1"
       }
     },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
     "node_modules/@vue/compiler-dom": {
       "version": "3.5.27",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.27.tgz",
@@ -7056,6 +7000,12 @@
         "postcss": "^8.5.6",
         "source-map-js": "^1.2.1"
       }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
       "version": "3.5.27",
@@ -7304,12 +7254,13 @@
       }
     },
     "node_modules/abbrev": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
-      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -7389,12 +7340,15 @@
       "license": "MIT"
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -7482,27 +7436,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/archiver-utils/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/archiver-utils/node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -7513,28 +7446,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
-    "node_modules/archiver-utils/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/are-docs-informative": {
@@ -7917,6 +7828,16 @@
         }
       }
     },
+    "node_modules/c12/node_modules/rc9": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "destr": "^2.0.3"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -8066,7 +7987,6 @@
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "consola": "^3.2.3"
       }
@@ -8125,6 +8045,64 @@
         "node": ">=12"
       }
     },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -8172,6 +8150,16 @@
       "resolved": "https://registry.npmjs.org/colortranslator/-/colortranslator-5.0.0.tgz",
       "integrity": "sha512-Z3UPUKasUVDFCDYAjP2fmlVRf1jFHJv1izAmPjiOa0OCIw1W7iC8PZ2GsoDa8uZv+mKyWopxxStT9q05+27h7w==",
       "license": "Apache-2.0"
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/comment-parser": {
       "version": "1.4.5",
@@ -8246,13 +8234,6 @@
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
       }
-    },
-    "node_modules/config-chain/node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/consola": {
       "version": "3.4.2",
@@ -8373,12 +8354,20 @@
       }
     },
     "node_modules/crossws": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
-      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.4.tgz",
+      "integrity": "sha512-w6c4OdpRNnudVmcgr7brb/+/HmYjMQvYToO/oTrprTwxRUiom3LYWU1PMWuD006okbUWpII1Ea9/+kwpUfmyRg==",
+      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "uncrypto": "^0.1.3"
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "srvx": ">=0.7.1"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
+          "optional": true
+        }
       }
     },
     "node_modules/css-declaration-sorter": {
@@ -8860,16 +8849,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/editorconfig/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/editorconfig/node_modules/minimatch": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
@@ -8988,9 +8967,9 @@
       }
     },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -9195,13 +9174,13 @@
       }
     },
     "node_modules/eslint-flat-config-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-flat-config-utils/-/eslint-flat-config-utils-3.0.0.tgz",
-      "integrity": "sha512-bzTam/pSnPANR0GUz4g7lo4fyzlQZwuz/h8ytsSS4w59N/JlXH/l7jmyNVBLxPz3B9/9ntz5ZLevGpazyDXJQQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-flat-config-utils/-/eslint-flat-config-utils-3.0.1.tgz",
+      "integrity": "sha512-VMA3u86bLzNAwD/7DkLtQ9lolgIOx2Sj0kTMMnBvrvEz7w0rQj4aGCR+lqsqtld63gKiLyT4BnQZ3gmGDXtvjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint/config-helpers": "^0.5.1",
+        "@eslint/config-helpers": "^0.5.2",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -9323,9 +9302,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "62.5.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.5.2.tgz",
-      "integrity": "sha512-n4plQz9u6xoX0QemOsBjU8S/V6XGRoBsad8v56Q9sEOKrcZTh489ld0qi7ONLNZsSlH0GBSi513DBvyavFckeQ==",
+      "version": "62.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.5.4.tgz",
+      "integrity": "sha512-U+Q5ppErmC17VFQl542eBIaXcuq975BzoIHBXyx7UQx/i4gyHXxPiBkonkuxWyFA98hGLALLUuD+NJcXqSGKxg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -9713,10 +9692,13 @@
       }
     },
     "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "license": "MIT"
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -10606,6 +10588,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/fzf": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fzf/-/fzf-0.5.2.tgz",
+      "integrity": "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -10672,37 +10660,22 @@
         "giget": "dist/cli.mjs"
       }
     },
-    "node_modules/git-up": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/git-up/-/git-up-8.1.1.tgz",
-      "integrity": "sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g==",
-      "license": "MIT",
-      "dependencies": {
-        "is-ssh": "^1.4.0",
-        "parse-url": "^9.2.0"
-      }
-    },
-    "node_modules/git-url-parse": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-16.1.0.tgz",
-      "integrity": "sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==",
-      "license": "MIT",
-      "dependencies": {
-        "git-up": "^8.1.0"
-      }
-    },
     "node_modules/glob": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.1.tgz",
-      "integrity": "sha512-B7U/vJpE3DkJ5WXTgTpTRN63uV42DseiXXKMwG14LQBXmsdeIoHAPbU/MEo6II0k5ED74uc2ZGTC6MwHFQhF6w==",
-      "license": "BlueOak-1.0.0",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
       "dependencies": {
-        "minimatch": "^10.1.2",
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
         "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
-      "engines": {
-        "node": "20 || >=22"
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -10721,21 +10694,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
-      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/global-directory": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
@@ -10749,6 +10707,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-directory/node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/globals": {
@@ -10834,10 +10801,45 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/h3-next": {
+      "name": "h3",
+      "version": "2.0.1-rc.14",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.14.tgz",
+      "integrity": "sha512-163qbGmTr/9rqQRNuqMqtgXnOUAkE4KTdauiC9y0E5iG1I65kte9NyfWvZw5RTDMt6eY+DtyoNzrQ9wA2BfvGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rou3": "^0.7.12",
+        "srvx": "^0.11.2"
+      },
+      "bin": {
+        "h3": "bin/h3.mjs"
+      },
+      "engines": {
+        "node": ">=20.11.1"
+      },
+      "peerDependencies": {
+        "crossws": "^0.4.1"
+      },
+      "peerDependenciesMeta": {
+        "crossws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/h3/node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "node_modules/happy-dom": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.5.0.tgz",
-      "integrity": "sha512-VQe+Q5CYiGOgcCERXhcfNsbnrN92FDEKciMH/x6LppU9dd0j4aTjCTlqONFOIMcAm/5JxS3+utowbXV1OoFr+g==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.5.3.tgz",
+      "integrity": "sha512-xqAxGnkRU0KNhheHpxb3uScqg/aehqUiVto/a9ApWMyNvnH9CAqHYq9dEPAovM6bOGbLstmTfGIln5ZIezEU0g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -10845,7 +10847,7 @@
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
         "@types/ws": "^8.18.1",
-        "entities": "^4.5.0",
+        "entities": "^6.0.1",
         "whatwg-mimetype": "^3.0.0",
         "ws": "^8.18.3"
       },
@@ -10854,9 +10856,9 @@
       }
     },
     "node_modules/happy-dom/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -11082,13 +11084,11 @@
       "license": "ISC"
     },
     "node_modules/ini": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
-      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ioredis": {
       "version": "5.9.2",
@@ -11269,15 +11269,6 @@
         "@types/estree": "*"
       }
     },
-    "node_modules/is-ssh": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.1.tgz",
-      "integrity": "sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==",
-      "license": "MIT",
-      "dependencies": {
-        "protocols": "^2.0.1"
-      }
-    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -11398,78 +11389,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/js-beautify/node_modules/abbrev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
-      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/js-beautify/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/js-beautify/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/js-beautify/node_modules/nopt": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
-      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "^2.0.0"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/js-beautify/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/js-cookie": {
@@ -11994,6 +11913,15 @@
         "listhen": "bin/listhen.mjs"
       }
     },
+    "node_modules/listhen/node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "node_modules/listhen/node_modules/pathe": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -12109,15 +12037,6 @@
         "type-level-regexp": "~0.1.17",
         "ufo": "^1.5.4",
         "unplugin": "^2.0.0"
-      }
-    },
-    "node_modules/magic-regexp/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/magic-string": {
@@ -12574,6 +12493,15 @@
       "integrity": "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==",
       "license": "MIT"
     },
+    "node_modules/nitropack/node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "node_modules/nitropack/node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -12667,18 +12595,19 @@
       "license": "MIT"
     },
     "node_modules/nopt": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
-      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^3.0.0"
+        "abbrev": "^2.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/normalize-path": {
@@ -12730,21 +12659,20 @@
       }
     },
     "node_modules/nuxt": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.3.0.tgz",
-      "integrity": "sha512-99Iw3E3L5/2QtJyV4errZ0axkX/S9IAFK0AHm0pmRHkCu37OFn8mz2P4/CYTt6B/TG3mcKbXAVaeuF2FsAc1cA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.3.1.tgz",
+      "integrity": "sha512-bl+0rFcT5Ax16aiWFBFPyWcsTob19NTZaDL5P6t0MQdK63AtgS6fN6fwvwdbXtnTk6/YdCzlmuLzXhSM22h0OA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dxup/nuxt": "^0.3.2",
-        "@nuxt/cli": "^3.32.0",
+        "@nuxt/cli": "^3.33.0",
         "@nuxt/devtools": "^3.1.1",
-        "@nuxt/kit": "4.3.0",
-        "@nuxt/nitro-server": "4.3.0",
-        "@nuxt/schema": "4.3.0",
-        "@nuxt/telemetry": "^2.6.6",
-        "@nuxt/vite-builder": "4.3.0",
-        "@unhead/vue": "^2.1.2",
+        "@nuxt/kit": "4.3.1",
+        "@nuxt/nitro-server": "4.3.1",
+        "@nuxt/schema": "4.3.1",
+        "@nuxt/telemetry": "^2.7.0",
+        "@nuxt/vite-builder": "4.3.1",
+        "@unhead/vue": "^2.1.3",
         "@vue/shared": "^3.5.27",
         "c12": "^3.3.3",
         "chokidar": "^5.0.0",
@@ -12767,20 +12695,20 @@
         "magic-string": "^0.30.21",
         "mlly": "^1.8.0",
         "nanotar": "^0.2.0",
-        "nypm": "^0.6.2",
+        "nypm": "^0.6.5",
         "ofetch": "^1.5.1",
         "ohash": "^2.0.11",
-        "on-change": "^6.0.1",
-        "oxc-minify": "^0.110.0",
-        "oxc-parser": "^0.110.0",
-        "oxc-transform": "^0.110.0",
+        "on-change": "^6.0.2",
+        "oxc-minify": "^0.112.0",
+        "oxc-parser": "^0.112.0",
+        "oxc-transform": "^0.112.0",
         "oxc-walker": "^0.7.0",
         "pathe": "^2.0.3",
-        "perfect-debounce": "^2.0.0",
+        "perfect-debounce": "^2.1.0",
         "pkg-types": "^2.3.0",
         "rou3": "^0.7.12",
         "scule": "^1.3.0",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "std-env": "^3.10.0",
         "tinyglobby": "^0.2.15",
         "ufo": "^1.6.3",
@@ -12788,7 +12716,7 @@
         "uncrypto": "^0.1.3",
         "unctx": "^2.5.0",
         "unimport": "^5.6.0",
-        "unplugin": "^2.3.11",
+        "unplugin": "^3.0.0",
         "unplugin-vue-router": "^0.19.2",
         "untyped": "^2.0.0",
         "vue": "^3.5.27",
@@ -12830,6 +12758,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nuxt/node_modules/unplugin": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
+      "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/nypm": {
@@ -12998,9 +12940,9 @@
       "license": "MIT"
     },
     "node_modules/oxc-minify": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.110.0.tgz",
-      "integrity": "sha512-KWGTzPo83QmGrXC4ml83PM9HDwUPtZFfasiclUvTV4i3/0j7xRRqINVkrL77CbQnoWura3CMxkRofjQKVDuhBw==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.112.0.tgz",
+      "integrity": "sha512-rkVSeeIRSt+RYI9uX6xonBpLUpvZyegxIg0UL87ev7YAfUqp7IIZlRjkgQN5Us1lyXD//TOo0Dcuuro/TYOWoQ==",
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -13009,36 +12951,36 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-minify/binding-android-arm-eabi": "0.110.0",
-        "@oxc-minify/binding-android-arm64": "0.110.0",
-        "@oxc-minify/binding-darwin-arm64": "0.110.0",
-        "@oxc-minify/binding-darwin-x64": "0.110.0",
-        "@oxc-minify/binding-freebsd-x64": "0.110.0",
-        "@oxc-minify/binding-linux-arm-gnueabihf": "0.110.0",
-        "@oxc-minify/binding-linux-arm-musleabihf": "0.110.0",
-        "@oxc-minify/binding-linux-arm64-gnu": "0.110.0",
-        "@oxc-minify/binding-linux-arm64-musl": "0.110.0",
-        "@oxc-minify/binding-linux-ppc64-gnu": "0.110.0",
-        "@oxc-minify/binding-linux-riscv64-gnu": "0.110.0",
-        "@oxc-minify/binding-linux-riscv64-musl": "0.110.0",
-        "@oxc-minify/binding-linux-s390x-gnu": "0.110.0",
-        "@oxc-minify/binding-linux-x64-gnu": "0.110.0",
-        "@oxc-minify/binding-linux-x64-musl": "0.110.0",
-        "@oxc-minify/binding-openharmony-arm64": "0.110.0",
-        "@oxc-minify/binding-wasm32-wasi": "0.110.0",
-        "@oxc-minify/binding-win32-arm64-msvc": "0.110.0",
-        "@oxc-minify/binding-win32-ia32-msvc": "0.110.0",
-        "@oxc-minify/binding-win32-x64-msvc": "0.110.0"
+        "@oxc-minify/binding-android-arm-eabi": "0.112.0",
+        "@oxc-minify/binding-android-arm64": "0.112.0",
+        "@oxc-minify/binding-darwin-arm64": "0.112.0",
+        "@oxc-minify/binding-darwin-x64": "0.112.0",
+        "@oxc-minify/binding-freebsd-x64": "0.112.0",
+        "@oxc-minify/binding-linux-arm-gnueabihf": "0.112.0",
+        "@oxc-minify/binding-linux-arm-musleabihf": "0.112.0",
+        "@oxc-minify/binding-linux-arm64-gnu": "0.112.0",
+        "@oxc-minify/binding-linux-arm64-musl": "0.112.0",
+        "@oxc-minify/binding-linux-ppc64-gnu": "0.112.0",
+        "@oxc-minify/binding-linux-riscv64-gnu": "0.112.0",
+        "@oxc-minify/binding-linux-riscv64-musl": "0.112.0",
+        "@oxc-minify/binding-linux-s390x-gnu": "0.112.0",
+        "@oxc-minify/binding-linux-x64-gnu": "0.112.0",
+        "@oxc-minify/binding-linux-x64-musl": "0.112.0",
+        "@oxc-minify/binding-openharmony-arm64": "0.112.0",
+        "@oxc-minify/binding-wasm32-wasi": "0.112.0",
+        "@oxc-minify/binding-win32-arm64-msvc": "0.112.0",
+        "@oxc-minify/binding-win32-ia32-msvc": "0.112.0",
+        "@oxc-minify/binding-win32-x64-msvc": "0.112.0"
       }
     },
     "node_modules/oxc-parser": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.110.0.tgz",
-      "integrity": "sha512-GijUR3K1Ln/QwMyYXRsBtOyzqGaCs9ce5pOug1UtrMg8dSiE7VuuRuIcyYD4nyJbasat3K0YljiKt/PSFPdSBA==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.112.0.tgz",
+      "integrity": "sha512-7rQ3QdJwobMQLMZwQaPuPYMEF2fDRZwf51lZ//V+bA37nejjKW5ifMHbbCwvA889Y4RLhT+/wLJpPRhAoBaZYw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@oxc-project/types": "^0.110.0"
+        "@oxc-project/types": "^0.112.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -13047,32 +12989,32 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-parser/binding-android-arm-eabi": "0.110.0",
-        "@oxc-parser/binding-android-arm64": "0.110.0",
-        "@oxc-parser/binding-darwin-arm64": "0.110.0",
-        "@oxc-parser/binding-darwin-x64": "0.110.0",
-        "@oxc-parser/binding-freebsd-x64": "0.110.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.110.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.110.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.110.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.110.0",
-        "@oxc-parser/binding-linux-ppc64-gnu": "0.110.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.110.0",
-        "@oxc-parser/binding-linux-riscv64-musl": "0.110.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.110.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.110.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.110.0",
-        "@oxc-parser/binding-openharmony-arm64": "0.110.0",
-        "@oxc-parser/binding-wasm32-wasi": "0.110.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.110.0",
-        "@oxc-parser/binding-win32-ia32-msvc": "0.110.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.110.0"
+        "@oxc-parser/binding-android-arm-eabi": "0.112.0",
+        "@oxc-parser/binding-android-arm64": "0.112.0",
+        "@oxc-parser/binding-darwin-arm64": "0.112.0",
+        "@oxc-parser/binding-darwin-x64": "0.112.0",
+        "@oxc-parser/binding-freebsd-x64": "0.112.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.112.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.112.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.112.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.112.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.112.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.112.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.112.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.112.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.112.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.112.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.112.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.112.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.112.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.112.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.112.0"
       }
     },
     "node_modules/oxc-transform": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.110.0.tgz",
-      "integrity": "sha512-/fymQNzzUoKZweH0nC5yvbI2eR0yWYusT9TEKDYVgOgYrf9Qmdez9lUFyvxKR9ycx+PTHi/reIOzqf3wkShQsw==",
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.112.0.tgz",
+      "integrity": "sha512-cIRRvZgrHfsAHrkt8LWdAX4+Do8R0MzQSfeo9yzErzHeYiuyNiP4PCTPbOy/wBXL4MYzt3ebrBa5jt3akQkKAg==",
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -13081,26 +13023,26 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-transform/binding-android-arm-eabi": "0.110.0",
-        "@oxc-transform/binding-android-arm64": "0.110.0",
-        "@oxc-transform/binding-darwin-arm64": "0.110.0",
-        "@oxc-transform/binding-darwin-x64": "0.110.0",
-        "@oxc-transform/binding-freebsd-x64": "0.110.0",
-        "@oxc-transform/binding-linux-arm-gnueabihf": "0.110.0",
-        "@oxc-transform/binding-linux-arm-musleabihf": "0.110.0",
-        "@oxc-transform/binding-linux-arm64-gnu": "0.110.0",
-        "@oxc-transform/binding-linux-arm64-musl": "0.110.0",
-        "@oxc-transform/binding-linux-ppc64-gnu": "0.110.0",
-        "@oxc-transform/binding-linux-riscv64-gnu": "0.110.0",
-        "@oxc-transform/binding-linux-riscv64-musl": "0.110.0",
-        "@oxc-transform/binding-linux-s390x-gnu": "0.110.0",
-        "@oxc-transform/binding-linux-x64-gnu": "0.110.0",
-        "@oxc-transform/binding-linux-x64-musl": "0.110.0",
-        "@oxc-transform/binding-openharmony-arm64": "0.110.0",
-        "@oxc-transform/binding-wasm32-wasi": "0.110.0",
-        "@oxc-transform/binding-win32-arm64-msvc": "0.110.0",
-        "@oxc-transform/binding-win32-ia32-msvc": "0.110.0",
-        "@oxc-transform/binding-win32-x64-msvc": "0.110.0"
+        "@oxc-transform/binding-android-arm-eabi": "0.112.0",
+        "@oxc-transform/binding-android-arm64": "0.112.0",
+        "@oxc-transform/binding-darwin-arm64": "0.112.0",
+        "@oxc-transform/binding-darwin-x64": "0.112.0",
+        "@oxc-transform/binding-freebsd-x64": "0.112.0",
+        "@oxc-transform/binding-linux-arm-gnueabihf": "0.112.0",
+        "@oxc-transform/binding-linux-arm-musleabihf": "0.112.0",
+        "@oxc-transform/binding-linux-arm64-gnu": "0.112.0",
+        "@oxc-transform/binding-linux-arm64-musl": "0.112.0",
+        "@oxc-transform/binding-linux-ppc64-gnu": "0.112.0",
+        "@oxc-transform/binding-linux-riscv64-gnu": "0.112.0",
+        "@oxc-transform/binding-linux-riscv64-musl": "0.112.0",
+        "@oxc-transform/binding-linux-s390x-gnu": "0.112.0",
+        "@oxc-transform/binding-linux-x64-gnu": "0.112.0",
+        "@oxc-transform/binding-linux-x64-musl": "0.112.0",
+        "@oxc-transform/binding-openharmony-arm64": "0.112.0",
+        "@oxc-transform/binding-wasm32-wasi": "0.112.0",
+        "@oxc-transform/binding-win32-arm64-msvc": "0.112.0",
+        "@oxc-transform/binding-win32-ia32-msvc": "0.112.0",
+        "@oxc-transform/binding-win32-x64-msvc": "0.112.0"
       }
     },
     "node_modules/oxc-walker": {
@@ -13188,34 +13130,12 @@
         "parse-statements": "1.0.11"
       }
     },
-    "node_modules/parse-path": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
-      "integrity": "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==",
-      "license": "MIT",
-      "dependencies": {
-        "protocols": "^2.0.0"
-      }
-    },
     "node_modules/parse-statements": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
       "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/parse-url": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-9.2.0.tgz",
-      "integrity": "sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/parse-path": "^7.0.0",
-        "parse-path": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.13.0"
-      }
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -13258,29 +13178,26 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
-      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -14075,12 +13992,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/protocols": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
-      "integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
-      "license": "MIT"
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -14161,13 +14072,13 @@
       }
     },
     "node_modules/rc9": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
-      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.0.tgz",
+      "integrity": "sha512-MGOue0VqscKWQ104udASX/3GYDcKyPI4j4F8gu/jHHzglpmy9a/anZK3PNe8ug6aZFl+9GxLtdhe3kVZuMaQbA==",
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.4",
-        "destr": "^2.0.3"
+        "destr": "^2.0.5"
       }
     },
     "node_modules/readable-stream": {
@@ -14876,9 +14787,9 @@
       }
     },
     "node_modules/srvx": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.10.1.tgz",
-      "integrity": "sha512-A//xtfak4eESMWWydSRFUVvCTQbSwivnGCEf8YGPe2eHU0+Z6znfUTCPF0a7oV3sObSOcrXHlL6Bs9vVctfXdg==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.2.tgz",
+      "integrity": "sha512-u6NbjE84IJwm1XUnJ53WqylLTQ3BdWRw03lcjBNNeMBD+EFjkl0Cnw1RVaGSqRAo38pOHOPXJH30M6cuTINUxw==",
       "license": "MIT",
       "bin": {
         "srvx": "bin/srvx.mjs"
@@ -14946,17 +14857,20 @@
       }
     },
     "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/string-width-cjs": {
@@ -14974,7 +14888,22 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-ansi": {
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -14986,6 +14915,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
@@ -14995,6 +14939,15 @@
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -15451,9 +15404,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.3.tgz",
-      "integrity": "sha512-AXSAQJu79WGc79/3e9/CR77I/KQgeY1AhNvcShIH4PTcGYyC4xv6H4R4AUOwkPS5799KlVDAu8zExeCrkGquiA==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.4.tgz",
+      "integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -15521,15 +15474,6 @@
         "unplugin": "^2.3.11"
       }
     },
-    "node_modules/unctx/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -15547,9 +15491,9 @@
       }
     },
     "node_modules/unhead": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.3.tgz",
-      "integrity": "sha512-Xg1vKNzkEDM4rrbQcSyKhjy2SAmSyV8qy/2iVdBeoln3Yxz31hlhpa1B2Yx5gBLj9G4MQ6+ZguDzpJTDgrhH+w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.4.tgz",
+      "integrity": "sha512-+5091sJqtNNmgfQ07zJOgUnMIMKzVKAWjeMlSrTdSGPB6JSozhpjUKuMfWEoLxlMAfhIvgOU8Me0XJvmMA/0fA==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^6.0.1"
@@ -15642,15 +15586,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/unimport/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/unimport/node_modules/unplugin-utils": {
@@ -16539,15 +16474,6 @@
         "vue": "^3.5.0"
       }
     },
-    "node_modules/vite-plugin-vue-tracer/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/vitest": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
@@ -16867,17 +16793,17 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -16899,6 +16825,59 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ws": {
@@ -17023,6 +17002,47 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yjs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8173,17 +8173,6 @@
       "integrity": "sha512-Z3UPUKasUVDFCDYAjP2fmlVRf1jFHJv1izAmPjiOa0OCIw1W7iC8PZ2GsoDa8uZv+mKyWopxxStT9q05+27h7w==",
       "license": "Apache-2.0"
     },
-    "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/comment-parser": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
@@ -8867,6 +8856,16 @@
       "bin": {
         "editorconfig": "bin/editorconfig"
       },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,10 @@
         "@iconify-json/lucide": "^1.2.87",
         "@iconify-json/simple-icons": "^1.2.68",
         "@nuxt/ui": "^4.4.0",
+        "@nuxtjs/robots": "^5.7.0",
+        "@nuxtjs/sitemap": "^7.6.0",
         "nuxt": "^4.3.0",
+        "nuxt-site-config": "^3.2.19",
         "tailwindcss": "^4.1.18"
       },
       "devDependencies": {
@@ -1320,6 +1323,12 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@fingerprintjs/botd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fingerprintjs/botd/-/botd-2.0.0.tgz",
+      "integrity": "sha512-yhuz23NKEcBDTHmGz/ULrXlGnbHenO+xZmVwuBkuqHUkqvaZ5TAA0kAgcRy4Wyo5dIBdkIf57UXX8/c9UlMLJg==",
+      "license": "MIT"
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.4",
@@ -3192,6 +3201,86 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/@nuxtjs/robots": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/robots/-/robots-5.7.0.tgz",
+      "integrity": "sha512-pkGtOP88rzIalvYE3rTCkJ+f0TDHfB/sbSCcA7inVemFa17JVu8AFlO4e+y4zthj+Jh98Tkf7yCuaDU5w3C1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fingerprintjs/botd": "^2.0.0",
+        "@nuxt/devtools-kit": "^3.1.1",
+        "@nuxt/kit": "^4.3.0",
+        "consola": "^3.4.2",
+        "defu": "^6.1.4",
+        "h3": "^1.15.5",
+        "nuxt-site-config": "^3.2.18",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.3.0",
+        "sirv": "^3.0.2",
+        "std-env": "^3.10.0",
+        "ufo": "^1.6.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "zod": ">=3"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nuxtjs/sitemap": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/sitemap/-/sitemap-7.6.0.tgz",
+      "integrity": "sha512-JuWwAFn9MDHWFO5C7lpV6DS86ZIrJItGfzCK1kN9WvgvDmTgal3xbfGCADmAaCWOVl2+dcPGHH6BCypQvUX0aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/devtools-kit": "^3.1.1",
+        "@nuxt/kit": "^4.3.0",
+        "chalk": "^5.6.2",
+        "defu": "^6.1.4",
+        "fast-xml-parser": "^5.3.3",
+        "nuxt-site-config": "^3.2.18",
+        "ofetch": "^1.5.1",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.3.0",
+        "radix3": "^1.1.2",
+        "semver": "^7.7.3",
+        "sirv": "^3.0.2",
+        "std-env": "^3.10.0",
+        "ufo": "^1.6.3",
+        "ultrahtml": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "zod": ">=3"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nuxtjs/sitemap/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
     },
     "node_modules/@one-ini/wasm": {
       "version": "0.1.1",
@@ -9876,6 +9965,24 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/fast-xml-parser": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.5.tgz",
+      "integrity": "sha512-JeaA2Vm9ffQKp9VjvfzObuMCjUYAp5WDYhRYL5LrBPY/jUDlUtOvDfot0vKSkB9tuX885BDHjtw4fZadD95wnA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -12814,6 +12921,42 @@
         }
       }
     },
+    "node_modules/nuxt-site-config": {
+      "version": "3.2.19",
+      "resolved": "https://registry.npmjs.org/nuxt-site-config/-/nuxt-site-config-3.2.19.tgz",
+      "integrity": "sha512-OUGfo8aJWbymheyb9S2u78ADX73C9qBf8u6BwEJiM82JBhvJTEduJBMlK8MWeh3x9NF+/YX4AYsY5hjfQE5jGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/devtools-kit": "^3.1.1",
+        "@nuxt/kit": "^4.3.0",
+        "h3": "^1.15.5",
+        "nuxt-site-config-kit": "3.2.19",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.3.0",
+        "sirv": "^3.0.2",
+        "site-config-stack": "3.2.19",
+        "ufo": "^1.6.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
+    "node_modules/nuxt-site-config-kit": {
+      "version": "3.2.19",
+      "resolved": "https://registry.npmjs.org/nuxt-site-config-kit/-/nuxt-site-config-kit-3.2.19.tgz",
+      "integrity": "sha512-5L9Dgw+QGnTLhVO7Km2oZU+wWllvNXLAFXUiZMX1dt37FKXX6v95ZKCVlFfnkSHQ+I2lmuUhFUpuORkOoVnU+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/kit": "^4.3.0",
+        "pkg-types": "^2.3.0",
+        "site-config-stack": "3.2.19",
+        "std-env": "^3.10.0",
+        "ufo": "^1.6.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
     "node_modules/nuxt/node_modules/cookie-es": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.0.tgz",
@@ -14786,6 +14929,21 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/site-config-stack": {
+      "version": "3.2.19",
+      "resolved": "https://registry.npmjs.org/site-config-stack/-/site-config-stack-3.2.19.tgz",
+      "integrity": "sha512-DJLEbH3WePmwdSDUCKCZTCc6xvY/Uuy3Qk5YG+5z5W7yMQbfRHRlEYhJbh4E431/V4aMROXH8lw5x8ETB71Nig==",
+      "license": "MIT",
+      "dependencies": {
+        "ufo": "^1.6.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "vue": "^3"
+      }
+    },
     "node_modules/slash": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -15053,6 +15211,18 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/structured-clone-es": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "@iconify-json/lucide": "^1.2.87",
     "@iconify-json/simple-icons": "^1.2.68",
     "@nuxt/ui": "^4.4.0",
+    "@nuxtjs/robots": "^5.7.0",
+    "@nuxtjs/sitemap": "^7.6.0",
     "nuxt": "^4.3.0",
+    "nuxt-site-config": "^3.2.19",
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "@iconify-json/lucide": "^1.2.87",
     "@iconify-json/simple-icons": "^1.2.68",
     "@nuxt/ui": "^4.4.0",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>marcel-tuinstra/devops:renovate/nuxt"
+  ]
+}

--- a/tests/unit/profiles.test.ts
+++ b/tests/unit/profiles.test.ts
@@ -22,8 +22,15 @@ describe('profiles data', () => {
       expect(profile.name).toBeTruthy()
       expect(profile.slug).toBeTruthy()
       expect(profile.descriptor).toBeTruthy()
+      expect(profile.avatarUrl).toBeTruthy()
       expect(profile.contacts).toBeInstanceOf(Array)
       expect(profile.contacts.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('should have valid avatar URLs from GitHub', () => {
+    for (const profile of profiles) {
+      expect(profile.avatarUrl).toMatch(/^https:\/\/github\.com\/[\w-]+\.png$/)
     }
   })
 

--- a/tests/unit/profiles.test.ts
+++ b/tests/unit/profiles.test.ts
@@ -22,14 +22,28 @@ describe('profiles data', () => {
       expect(profile.name).toBeTruthy()
       expect(profile.slug).toBeTruthy()
       expect(profile.descriptor).toBeTruthy()
-      expect(profile.ctaLink).toBeTruthy()
-      expect(profile.ctaLabel).toBeTruthy()
+      expect(profile.contacts).toBeInstanceOf(Array)
+      expect(profile.contacts.length).toBeGreaterThan(0)
     }
   })
 
-  it('should have valid CTA links', () => {
+  it('should have valid contact URLs', () => {
+    const validTypes = ['website', 'linkedin', 'github', 'email', 'phone']
+
     for (const profile of profiles) {
-      expect(profile.ctaLink).toMatch(/^https?:\/\//)
+      for (const contact of profile.contacts) {
+        expect(validTypes).toContain(contact.type)
+        expect(contact.url).toBeTruthy()
+
+        // Validate URL format based on type
+        if (contact.type === 'email') {
+          expect(contact.url).toMatch(/^mailto:/)
+        } else if (contact.type === 'phone') {
+          expect(contact.url).toMatch(/^tel:/)
+        } else {
+          expect(contact.url).toMatch(/^https?:\/\//)
+        }
+      }
     }
   })
 })


### PR DESCRIPTION
## release: 2026-02-09

### Changes

- feat(visual): add JetBrains Mono font, GitHub avatars, and design tokens (#15)
- fix: add security-events permission for Trivy scanning in CD workflows
- chore: Adopt devops platform templates + Docker security scanning (#19)
- feat(seo): add sitemap, robots.txt, and enhanced meta tags
- feat(landing): enhance hub UX with improved cards and accessibility
- feat(error): add custom 404 page with hub navigation
- fix: regenerate package-lock.json to sync with package.json
- fix(profile): update Marcel's descriptor to Full-Stack Developer
- feat(profile): add digital business card pages for /marcel and /daan
- chore: add Docker healthcheck and use npm ci for reproducible builds
- feat(profile): add contact methods for digital business cards
- chore(deps): add shared devops Renovate preset
- chore(ci): add release PR workflow
