### PR TITLE
chore: disable staging deployment

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,8 +1,9 @@
 name: Deploy Staging
 
 on:
-  push:
-    branches: [develop]
+  workflow_dispatch: # Manual trigger only - staging disabled
+  # push:
+  #   branches: [develop]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Disable automatic staging deployment on push to develop
- Staging subdomain has been disabled (overkill for solo dev)

## Changes
- Changed trigger from `push` to `workflow_dispatch` (manual only)
- Original trigger commented out for easy re-enabling