### PR TITLE
chore: standardize workflow names for clearer notifications

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,4 +1,4 @@
-name: CI Docker
+name: site-tuinstra-ci-docker
 
 on:
   pull_request:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,4 +1,4 @@
-name: Deploy Production
+name: site-tuinstra-deploy-production
 
 on:
   push:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,4 +1,4 @@
-name: Deploy Staging
+name: site-tuinstra-deploy-staging
 
 on:
   workflow_dispatch: # Manual trigger only - staging disabled

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,4 @@
-name: PR Checks
+name: site-tuinstra-pr-checks
 
 on:
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Create Release PR
+name: site-tuinstra-release-pr
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- standardize workflow names to repo-purpose format for clearer notifications
- keep workflow triggers and behavior unchanged
- no CI/CD logic changes